### PR TITLE
Groups: show if public

### DIFF
--- a/roadrecon/frontend/src/app/appmain/aadobjects.service.ts
+++ b/roadrecon/frontend/src/app/appmain/aadobjects.service.ts
@@ -17,6 +17,7 @@ export interface GroupsItem {
   objectId: string;
   objectType: string;
   mail: string;
+  isPublic: boolean;
   membershipRule: string;
   memberOf: GroupsItem[];
   memberUsers: UsersItem[];

--- a/roadrecon/frontend/src/app/appmain/groups/groups.component.html
+++ b/roadrecon/frontend/src/app/appmain/groups/groups.component.html
@@ -28,6 +28,11 @@
       <td mat-cell *matCellDef="let row">{{row.mail}}</td>
     </ng-container>
 
+    <ng-container matColumnDef="isPublic">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Public?</th>
+      <td mat-cell *matCellDef="let row">{{row.isPublic}}</td>
+    </ng-container>
+
     <ng-container matColumnDef="jobTitle">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>Job title</th>
       <td mat-cell *matCellDef="let row">{{row.jobTitle}}</td>

--- a/roadrecon/frontend/src/app/appmain/groups/groups.component.ts
+++ b/roadrecon/frontend/src/app/appmain/groups/groups.component.ts
@@ -20,7 +20,7 @@ export class GroupsComponent implements AfterViewInit, OnInit {
   constructor(private service: DatabaseService) {  }
 
   /** Columns displayed in the table. Columns IDs can be added, removed, or reordered. */
-  displayedColumns = ['displayName', 'description', 'type', 'mail'];
+  displayedColumns = ['displayName', 'description', 'type', 'mail', 'isPublic'];
 
   ngOnInit() {
     this.dataSource = new MatTableDataSource();

--- a/roadrecon/frontend/src/app/appmain/groups/groupsdialog/groupsdialog.component.html
+++ b/roadrecon/frontend/src/app/appmain/groups/groupsdialog/groupsdialog.component.html
@@ -9,6 +9,7 @@
         <tr><th>ObjectId</th><td>{{ group.objectId }}</td></tr>
         <tr *ngIf="group.membershipRule != null"><th>Dynamic Membership</th><td>{{ group.membershipRule }}</td></tr>
         <tr *ngIf="group.mail != null"><th>Email</th><td>{{ group.mail }}</td></tr>
+        <tr *ngIf="group.isPublic != null"><th>Public?</th><td>{{ group.isPublic }}</td></tr>
         <tr *ngIf="group.createdDateTime != null"><th>Created</th><td>{{ group.createdDateTime }}</td></tr>
         <tr><th>Group type</th><td>{{ group.dirSyncEnabled? 'Synced with AD':'Cloud-only' }}</td></tr>
       </table>

--- a/roadrecon/roadtools/roadrecon/server.py
+++ b/roadrecon/roadtools/roadrecon/server.py
@@ -61,7 +61,7 @@ class AppRoleAssignmentsSchema(ma.SQLAlchemyAutoSchema):
 class GroupsSchema(ma.Schema):
     class Meta:
         model = Group
-        fields = ('displayName', 'description', 'createdDateTime', 'dirSyncEnabled', 'objectId', 'objectType', 'mail')
+        fields = ('displayName', 'description', 'createdDateTime', 'dirSyncEnabled', 'objectId', 'objectType', 'mail', 'isPublic')
 
 class SimpleServicePrincipalsSchema(ma.Schema):
     """


### PR DESCRIPTION
M365 Groups can be public or private. Obviously public Groups are _interesting_ ;)
The `isPublic` field is already collected by ROADtools and present in the DB so I think it's helpful to show it in the frontend

![m365-groups-20-roadrecon-1](https://user-images.githubusercontent.com/550823/109431053-d5c75380-7a04-11eb-9f66-7652832bd8e2.png)
![m365-groups-21-roadrecon-2](https://user-images.githubusercontent.com/550823/109431055-d5c75380-7a04-11eb-9959-c1eff1bf37e5.png)


