### PR TITLE
Fix ValueError in database.py

### DIFF
--- a/roadlib/roadtools/roadlib/metadef/database.py
+++ b/roadlib/roadtools/roadlib/metadef/database.py
@@ -29,7 +29,10 @@ class DateTime(TypeDecorator):
             # Sometimes it ends on a Z, sometimes it doesn't
             if value[-1] == 'Z':
                 if '.' in value:
-                    value = datetime.datetime.strptime(value[:-2], '%Y-%m-%dT%H:%M:%S.%f')
+                    try:
+                        value = datetime.datetime.strptime(value[:-2], '%Y-%m-%dT%H:%M:%S.%f')
+                    except ValueError:
+                        value = datetime.datetime.strptime(value[:-2], '%Y-%m-%dT%H:%M:%S.')
                 else:
                     value = datetime.datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ')
             elif '.' in value:


### PR DESCRIPTION
This commit fixes the following error:

```
sqlalchemy.exc.StatementError: (builtins.ValueError) time data '2021-03-12T14:28:14.' does not match format '%Y-%m-%dT%H:%M:%S.%f'
```