### PR TITLE
ROAD2timeline Plugin

### DIFF
--- a/roadrecon/roadtools/roadrecon/main.py
+++ b/roadrecon/roadtools/roadrecon/main.py
@@ -75,7 +75,8 @@ def main():
     plugins_list = {
         'policies': 'Parse conditional access policies',
         'bloodhound': 'Export Azure AD data to a custom BloodHound version',
-        'xlsexport': 'Export data to an Excel file'
+        'xlsexport': 'Export data to an Excel file',
+        'road2timeline': 'Generate a forensic timeline from Azure AD object timestamps',
         # 'grep': 'Export grep-compatible lists'
     }
 

--- a/roadrecon/roadtools/roadrecon/plugins/road2timeline.py
+++ b/roadrecon/roadtools/roadrecon/plugins/road2timeline.py
@@ -23,12 +23,20 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 import argparse
+import logging
+import yaml
+import sqlalchemy
 
-from typing import Optional
-
+import pandas as pd
+import numpy as np
 import roadtools.roadlib.metadef.database as database
 
+from pathlib import Path
+from typing import Dict, Optional
+
 DESCRIPTION = "Timeline analysis of Azure AD objects"
+
+logger = logging.getLogger(__name__)
 
 def create_args_parser():
     parser = argparse.ArgumentParser(
@@ -50,12 +58,77 @@ def create_args_parser():
 
 def add_args(parser: argparse.ArgumentParser):
     parser.add_argument(
-        '-f', '--file',
+        '-t', '--template-file',
         action='store',
         help='File containing string templates to translate Azure AD objects into a timeline \
             entry. Defaults to `road2timeline.yaml`',
         default='road2timeline.yaml'
     )
+    parser.add_argument(
+        '-f', '--output-file',
+        action='store',
+        help='File to save timeline outputs. Output format determined by file extension. Supported extensions include: [csv, pickle, json]',
+        default='timeline-output.json',
+    )
+
+
+def populate_timeline_entry(
+    row: pd.Series, 
+    timeline_entry_templates: Dict[str, Dict[str, str]]
+    ) -> str:
+    """Attempts to populate a timeline entry template with
+    the relevant fields from a row in the database.
+    """
+
+    table_templates = timeline_entry_templates.get(row._table_name, {})
+    template_text = table_templates.get(row._source_timestamp)
+    if template_text:
+        try:
+            return template_text.format(**row.to_dict())
+        except Exception as exc:
+            logger.error(f"There was a problem parsing the message: {str(exc)}")
+            return f"Error parsing template {row._table_name}.{row._source_timestamp}: " + row.to_json()
+    else:
+        return f"No template found for {row._table_name}.{row._source_timestamp}: " + row.to_json()
+
+
+
+def to_dataframe(
+    session: sqlalchemy.orm.session.Session, 
+    table: sqlalchemy.ext.declarative.api.DeclarativeMeta
+    ) -> pd.DataFrame:
+    """Reads sqlite table and converts to pd.DataFrame.
+    This also converts the string values in datetime columns
+    into their equivalent Python `datetime` representation.
+    """
+
+    rows = session.query(table).all()
+    if not rows:
+        return pd.DataFrame()
+
+    df = pd.json_normalize([{
+        **row._asdict(), 
+        '_object_id': getattr(row, "objectId", None) or getattr(row, "id", None) or "Identifier Not Found",
+        }
+        for row in rows
+    ]).assign(_table_name=table.name)
+
+    for column in table.columns:
+        # Attempts to coerce sqlite datetime columns
+        # into a python Datetime object.
+        if type(column.type) == sqlalchemy.sql.sqltypes.DATETIME:
+            if column.name in df.columns:
+                df[column.name] = df[column.name].apply(pd.to_datetime, errors="coerce")
+            
+    return df
+
+
+def copy_dataframe_by_col(df: pd.DataFrame, col: str) -> pd.DataFrame:
+    """Returns a pd.DataFrame with new columns for a given datetime field"""
+    df = df.copy()
+    df['_timestamp'] = df[col]
+    df['_source_timestamp'] = col
+    return df[df[col].notnull()]
 
 
 def main(args: Optional[argparse.Namespace] = None):
@@ -64,9 +137,51 @@ def main(args: Optional[argparse.Namespace] = None):
         args = parser.parse_args()
 
     db_url = database.parse_db_argument(args.database)
-    session = database.get_session(database.init(dburl=db_url))
+    engine = database.init(dburl=db_url)
+    db_metadata = sqlalchemy.MetaData(bind=engine, schema='main')
+    db_metadata.reflect()
+    session = database.get_session(engine)
 
-    pass
+    templates_fp = Path(args.template_file)
+    if not templates_fp.exists():
+        print(f"Template file {templates_fp} not found, defaulting to built-in templates")
+        templates_fp = Path(__file__).with_suffix(".yaml")
+
+    print(f"Loading timeline entry templates from {templates_fp}")
+    timeline_entry_templates = yaml.safe_load(
+        templates_fp.read_text(encoding="utf-8", errors="replace")
+    )
+
+    dataframes = []
+    for table in db_metadata.sorted_tables:
+        df = to_dataframe(session, table)
+        for col in df.select_dtypes(include=[np.datetime64]).columns:
+            dataframes.append(
+                copy_dataframe_by_col(df, col))
+
+    timeline = (
+        pd.concat(dataframes, ignore_index=True)
+        .assign(_message=lambda x: x.apply(populate_timeline_entry, args=(timeline_entry_templates,), axis=1))
+        # Hacky way get these columns sorted first
+        .set_index(['_source_timestamp', '_table_name', '_message', '_object_id'])
+        .sort_index(axis=1) # The remaining columns are then sorted alphabetically
+        .reset_index()
+        .set_index('_timestamp') # Set the index datetime
+        .sort_index() # Sort by timestamp
+    )
+
+    if args.output_file.endswith('.json'):
+        timeline.to_json(args.output_file, orient='records', lines=True, default_handler=str)
+    elif args.output_file.endswith('.pickle'):
+        timeline.to_pickle(args.output_file)
+    elif args.output_file.endswith('.csv'):
+        timeline.to_csv(args.output_file)
+    else:
+        raise ValueError(f"Unable to determine output format \
+            for `--output-file` argument {args.output_file}. \
+            Filename must end with one of: [json, pickle, csv]"
+        )
+
 
 if __name__ == '__main__':
     main()

--- a/roadrecon/roadtools/roadrecon/plugins/road2timeline.py
+++ b/roadrecon/roadtools/roadrecon/plugins/road2timeline.py
@@ -1,0 +1,72 @@
+"""
+ROAD2Timeline Plugin
+Contributed by Ryan Marcotte Cobb (Secureworks)
+
+Copyright 2020 - MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+import argparse
+
+from typing import Optional
+
+import roadtools.roadlib.metadef.database as database
+
+DESCRIPTION = "Timeline analysis of Azure AD objects"
+
+def create_args_parser():
+    parser = argparse.ArgumentParser(
+        # TODO: Remove?
+        #add_help=True,
+        description=DESCRIPTION,
+        # TODO: Remove?
+        #formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        '-d', '--database',
+        action='store',
+        help='Database file. Can be the local database name for SQLite, or an SQLAlchemy '
+             'compatible URL such as postgresql+psycopg2://dirkjan@/roadtools',
+        default='roadrecon.db'
+    )
+    return parser
+
+
+def add_args(parser: argparse.ArgumentParser):
+    parser.add_argument(
+        '-f', '--file',
+        action='store',
+        help='File containing string templates to translate Azure AD objects into a timeline \
+            entry. Defaults to `road2timeline.yaml`',
+        default='road2timeline.yaml'
+    )
+
+
+def main(args: Optional[argparse.Namespace] = None):
+    if args is None:
+        parser = create_args_parser()
+        args = parser.parse_args()
+
+    db_url = database.parse_db_argument(args.database)
+    session = database.get_session(database.init(dburl=db_url))
+
+    pass
+
+if __name__ == '__main__':
+    main()

--- a/roadrecon/roadtools/roadrecon/plugins/road2timeline.py
+++ b/roadrecon/roadtools/roadrecon/plugins/road2timeline.py
@@ -36,7 +36,6 @@ from typing import Dict, Optional
 
 DESCRIPTION = "Timeline analysis of Azure AD objects"
 
-logger = logging.getLogger(__name__)
 
 def create_args_parser():
     parser = argparse.ArgumentParser(
@@ -86,7 +85,7 @@ def populate_timeline_entry(
         try:
             return template_text.format(**row.to_dict())
         except Exception as exc:
-            logger.error(f"There was a problem parsing the message: {str(exc)}")
+            print(f"There was a problem parsing the message: {str(exc)}")
             return f"Error parsing template {row._table_name}.{row._source_timestamp}: Object ID - {row._object_id}" 
     else:
         return f"No template found for {row._table_name}.{row._source_timestamp}: Object ID - {row._object_id}"

--- a/roadrecon/roadtools/roadrecon/plugins/road2timeline.py
+++ b/roadrecon/roadtools/roadrecon/plugins/road2timeline.py
@@ -61,7 +61,7 @@ def add_args(parser: argparse.ArgumentParser):
         '-t', '--template-file',
         action='store',
         help='File containing string templates to translate Azure AD objects into a timeline \
-            entry. Defaults to `road2timeline.yaml`',
+            entry. Defaults to `road2timeline.yaml` in the current working directory.',
         default='road2timeline.yaml'
     )
     parser.add_argument(

--- a/roadrecon/roadtools/roadrecon/plugins/road2timeline.py
+++ b/roadrecon/roadtools/roadrecon/plugins/road2timeline.py
@@ -67,8 +67,8 @@ def add_args(parser: argparse.ArgumentParser):
     parser.add_argument(
         '-f', '--output-file',
         action='store',
-        help='File to save timeline outputs. Output format determined by file extension. Supported extensions include: [csv, pickle, json]',
-        default='timeline-output.json',
+        help='File to save timeline outputs. Output format determined by file extension. Supported extensions include: [csv, pickle, jsonl]',
+        default='timeline-output.jsonl',
     )
 
 
@@ -87,9 +87,9 @@ def populate_timeline_entry(
             return template_text.format(**row.to_dict())
         except Exception as exc:
             logger.error(f"There was a problem parsing the message: {str(exc)}")
-            return f"Error parsing template {row._table_name}.{row._source_timestamp}: " + row.to_json()
+            return f"Error parsing template {row._table_name}.{row._source_timestamp}: Object ID - {row._object_id}" 
     else:
-        return f"No template found for {row._table_name}.{row._source_timestamp}: " + row.to_json()
+        return f"No template found for {row._table_name}.{row._source_timestamp}: Object ID - {row._object_id}"
 
 
 
@@ -144,7 +144,7 @@ def main(args: Optional[argparse.Namespace] = None):
 
     templates_fp = Path(args.template_file)
     if not templates_fp.exists():
-        print(f"Template file {templates_fp} not found, defaulting to built-in templates")
+        print(f"Timeline entry template file {templates_fp} not found, defaulting to built-in templates")
         templates_fp = Path(__file__).with_suffix(".yaml")
 
     print(f"Loading timeline entry templates from {templates_fp}")
@@ -170,7 +170,7 @@ def main(args: Optional[argparse.Namespace] = None):
         .sort_index() # Sort by timestamp
     )
 
-    if args.output_file.endswith('.json'):
+    if args.output_file.endswith('.jsonl'):
         timeline.to_json(args.output_file, orient='records', lines=True, default_handler=str)
     elif args.output_file.endswith('.pickle'):
         timeline.to_pickle(args.output_file)
@@ -179,7 +179,7 @@ def main(args: Optional[argparse.Namespace] = None):
     else:
         raise ValueError(f"Unable to determine output format \
             for `--output-file` argument {args.output_file}. \
-            Filename must end with one of: [json, pickle, csv]"
+            Filename must end with one of: [jsonl, pickle, csv]"
         )
 
 

--- a/roadrecon/roadtools/roadrecon/plugins/road2timeline.py
+++ b/roadrecon/roadtools/roadrecon/plugins/road2timeline.py
@@ -2,7 +2,7 @@
 ROAD2Timeline Plugin
 Contributed by Ryan Marcotte Cobb (Secureworks)
 
-Copyright 2020 - MIT License
+Copyright 2022 - MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -33,11 +33,7 @@ from typing import Dict, Optional
 # Currently, there is no good way to specify
 # plugin-specific imports. Therefore, we need
 # to manually check that the necessary modules
-# are present in the environment. This will
-# likely be solved using namespace packages
-# in the future, since that is the natural
-# solution for lazy-loading modules with their
-# own dependencies in a predictable namespace.
+# are present in the environment.
 
 try:
     import yaml
@@ -162,14 +158,6 @@ def to_dataframe(
             if column.name in df.columns:
                 df[column.name] = df[column.name].apply(pd.to_datetime, errors="coerce")
 
-    # for column in df.columns:
-    #    try:
-    #        df[column] = df[column].apply(pd.to_datetime, errors="raise")
-    #    except Exception as exc:
-    #        # TODO: Remove, debug only
-    #        print(column, exc)
-    #        continue
-
     return df
 
 
@@ -206,12 +194,12 @@ def main(args: Optional[argparse.Namespace] = None) -> Path:
     # Connect to the database
     db_url = database.parse_db_argument(args.database)
     engine = database.init(dburl=db_url)
+    session = database.get_session(engine)
 
     # Do some reflection to grab the tables
     # and their respective column types
     db_metadata = sqlalchemy.MetaData(bind=engine, schema="main")
     db_metadata.reflect()
-    session = database.get_session(engine)
 
     # Find the templates file which is used
     # to populate timeline entries from the
@@ -268,10 +256,6 @@ def main(args: Optional[argparse.Namespace] = None) -> Path:
     # Infer the output format based on the
     # file extension of the `--output-file`
     # argument.
-    #
-    # While we could use any output format(s)
-    # that `pd.DataFrame` supports, there may
-    # be issues serializing some complex types.
     output_file = Path(args.output_file)
 
     if output_file.suffix == ".jsonl":

--- a/roadrecon/roadtools/roadrecon/plugins/road2timeline.yaml
+++ b/roadrecon/roadtools/roadrecon/plugins/road2timeline.yaml
@@ -1,0 +1,21 @@
+AppRoleAssignments:
+  creationTimestamp: App role for {resourceDisplayName} ({resourceId}) assigned to {principalType} named {principalDisplayName} ({principalId})
+Devices:
+  lastDirSyncTime: 'Directory sync for {deviceOSType} device {displayName} (SID: {onPremisesSecurityIdentifier}, Device ID: {deviceId}, Object ID: {objectId})'
+  approximateLastLogonTimestamp: 'Approximate last logon for {deviceOSType} device {displayName} (Device ID: {deviceId})'
+Groups:
+  createdDateTime: 'Group {displayName} was created by application {createdByAppId} (
+    Group Object ID: {objectId}, SID: {onPremisesSecurityIdentifier})'
+  lastDirSyncTime: 'Directory sync for {visibility} group {displayName} (On-Prem SID: {onPremisesSecurityIdentifier}, Cloud SID: {cloudSecurityIdentifier})'
+  renewedDateTime: 'Renewed {visibility} group {displayName} (Cloud SID: {cloudSecurityIdentifier})'
+OAuth2PermissionGrants:
+  expiryTime: 'Delegated permission expired for {scope} scope on {resourceId} for principals: {consentType}'
+Users:
+  acceptedOn: '{creationType} {userState} for {userType} user {displayName} (UPN: {userPrincipalName})'
+  createdDateTime: 'User {userPrincipalName} was created in the directory (Cloud SID: {cloudSecurityIdentifier})'
+  invitedOn: 'User {userPrincipalName} was invited to the directory (Cloud SID: {cloudSecurityIdentifier})'
+  lastDirSyncTime: 'Directory sync for user {userPrincipalName} (On-Prem SID: {onPremisesSecurityIdentifier}, Cloud SID: {cloudSecurityIdentifier}, Immutable ID: {immutableId})'
+  lastPasswordChangeDateTime: 'Cloud password was changed for user {userPrincipalName} (Cloud SID: {cloudSecurityIdentifier})'
+  onPremisesPasswordChangeTimestamp: 'On-Prem password was changed for user {userPrincipalName} (On-Prem SID: {onPremisesSecurityIdentifier}, Cloud SID: {cloudSecurityIdentifier}, Immutable ID: {immutableId})'
+  refreshTokensValidFromDateTime: 'Refresh tokens renewed for user {userPrincipalName} (On-Prem SID: {onPremisesSecurityIdentifier}, Cloud SID: {cloudSecurityIdentifier}, Immutable ID: {immutableId})'
+  userStateChangedOn: 'State changed to {userState} for {userType} user {displayName} (UPN: {userPrincipalName})'

--- a/roadrecon/roadtools/roadrecon/plugins/road2timeline.yaml
+++ b/roadrecon/roadtools/roadrecon/plugins/road2timeline.yaml
@@ -17,5 +17,5 @@ Users:
   lastDirSyncTime: 'Directory sync for user {userPrincipalName} (On-Prem SID: {onPremisesSecurityIdentifier}, Cloud SID: {cloudSecurityIdentifier}, Immutable ID: {immutableId})'
   lastPasswordChangeDateTime: 'Cloud password was changed for user {userPrincipalName} (Cloud SID: {cloudSecurityIdentifier})'
   onPremisesPasswordChangeTimestamp: 'On-Prem password was changed for user {userPrincipalName} (On-Prem SID: {onPremisesSecurityIdentifier}, Cloud SID: {cloudSecurityIdentifier}, Immutable ID: {immutableId})'
-  refreshTokensValidFromDateTime: 'Refresh tokens renewed for user {userPrincipalName} (On-Prem SID: {onPremisesSecurityIdentifier}, Cloud SID: {cloudSecurityIdentifier}, Immutable ID: {immutableId})'
+  refreshTokensValidFromDateTime: 'Refresh tokens revoked for user {userPrincipalName} (On-Prem SID: {onPremisesSecurityIdentifier}, Cloud SID: {cloudSecurityIdentifier}, Immutable ID: {immutableId})'
   userStateChangedOn: 'State changed to {userState} for {userType} user {displayName} (UPN: {userPrincipalName})'

--- a/roadrecon/setup.py
+++ b/roadrecon/setup.py
@@ -15,6 +15,7 @@ setup(name='roadrecon',
           'Programming Language :: Python :: 3.8',
       ],
       packages=['roadtools.roadrecon', 'roadtools.roadrecon.plugins'],
+      package_data={'roadtools.roadrecon.plugins': ['*.yaml']},
       install_requires=[
           'roadlib',
           'flask',


### PR DESCRIPTION
Hi Dirk-jan,

Here is a PR for a new ROADtools plugin called ROAD2timeline.

ROAD2timeline was inspired by forensic tools like `plaso`/`log2timeline` that can generate a forensic timeline of events based on the various timestamps found in evidence (usually file system MACB times, etc).

The database created by ROADtools contains many timestamps across its tables. Here is a dump of the `DATETIME` columns based on the database schema:

```
AppRoleAssignments
|_ deletionTimestamp
|_ creationTimestamp

Applications
|_ deletionTimestamp

Contacts
|_ deletionTimestamp
|_ lastDirSyncTime

Devices
|_ deletionTimestamp
|_ approximateLastLogonTimestamp
|_ complianceExpiryTime
|_ lastDirSyncTime

DirectoryRoles
|_ deletionTimestamp

ExtensionPropertys
|_ deletionTimestamp

Groups
|_ deletionTimestamp
|_ createdDateTime
|_ expirationDateTime
|_ lastDirSyncTime
|_ renewedDateTime

OAuth2PermissionGrants
|_ expiryTime
|_ startTime

Policys
|_ deletionTimestamp

RoleDefinitions
|_ deletionTimestamp

ServicePrincipals
|_ deletionTimestamp
|_ preferredTokenSigningKeyEndDateTime

TenantDetails
|_ deletionTimestamp
|_ companyLastDirSyncTime
|_ createdDateTime

Users
|_ deletionTimestamp
|_ acceptedOn
|_ createdDateTime
|_ employeeHireDate
|_ invitedOn
|_ lastDirSyncTime
|_ lastPasswordChangeDateTime
|_ onPremisesPasswordChangeTimestamp
|_ refreshTokensValidFromDateTime
|_ userStateChangedOn
```

ROAD2timeline generates a timeline of all the Azure AD object timestamps in the ROADtools database. For example, if there are 10 rows and 4 datetime columns (ie, timestamps) in the `Devices` table, ROAD2timeline will create a timeline containing 40 entries in chronologically-sorted order. 

To make it easier for humans to review the timeline, I also included simple templates that are populated from the column values in a given row. These are defined and can be customized in a YAML file. For example:

```yaml
Devices:
  lastDirSyncTime: 'Directory sync for {deviceOSType} device {displayName} (SID: {onPremisesSecurityIdentifier}, Device ID: {deviceId}, Object ID: {objectId})'
  approximateLastLogonTimestamp: 'Approximate last logon for {deviceOSType} device {displayName} (Device ID: {deviceId})'
```

The plugin will generate a timeline based on all the datetime columns in the database schema, even if a corresponding template is not defined. In this PR, I provide templates for about half of the columns in the schema. It would be helpful to get community feedback on the most useful way to represent these timeline entries. Users can also provide their own template file with a CLI option.

## Example Usage

```bash
roadrecon plugin road2timeline --help
usage: roadrecon plugin road2timeline [-h] [-d DATABASE] [-t TEMPLATE_FILE] [-f OUTPUT_FILE]

Timeline analysis of Azure AD objects

optional arguments:
  -h, --help            show this help message and exit
  -d DATABASE, --database DATABASE
                        Database file. Can be the local database name for SQLite, or an SQLAlchemy compatible URL such as postgresql+psycopg2://dirkjan@/roadtools
  -t TEMPLATE_FILE, --template-file TEMPLATE_FILE
                        File containing string templates to translate Azure AD objects into a timeline entry. Defaults to `road2timeline.yaml` in the current working directory.
  -f OUTPUT_FILE, --output-file OUTPUT_FILE
                        File to save timeline outputs. Output format determined by file extension. Supported extensions include: [csv, pickle, jsonl, parquet]
```

```bash
roadrecon plugin road2timeline -d roadrecon.db -f timeline.parquet
```

```
Timeline entry template file road2timeline.yaml not found, defaulting to built-in templates
Loading timeline entry templates from <redacted>/ROADtools/roadrecon/roadtools/roadrecon/plugins/road2timeline.yaml
Timeline saved to file <redacted>/timeline.parquet
```

Users can analyze the timeline with their tool of choice. Here is an example of how I often parse these timelines in `pandas`:

```python
import pandas as pd
timeline_df = pd.read_parquet("timeline.parquet")
timeline_df.groupby([
    pd.Grouper(freq="10T"),
    "_table_name",
    "_timestamp_column",
    "_message",
])._object_id.nunique().to_frame()
```

<img width="804" alt="image" src="https://user-images.githubusercontent.com/39737036/177821201-8d7a3939-246b-4b40-9c49-9790f7b9b1c9.png">

## Known Issues/Caveats/Questions

- This plugin requires the `pandas` module (and its `numpy` dependency). If the users wants to export the timeline as a `parquet` file, then `pyarrow` is also required. I am not sure what would be the best way to make these optionally installable or otherwise not break functionality for folks who want to run ROADtools without this plugin.
- I am unfamiliar with the convention for the module `add_args` function. I mostly copied how other plugins were structured.
- We need to ensure that the YAML file of template strings is included in the built Python package. I added this to the `setup.py`, but it could use testing.
- As mentioned above, only about half of the datetime columns have a corresponding template in the YAML file. I figured you and/or the community would have input on the best way to represent these timeline entries.
- Timestamps contained in nested objects (ie, inside JSON arrays) are currently not supported/parsed. I am generating the timeline based on the database schema, not by searching for timestamps inside the row values.
- It works fine in my test tenants, but these are relatively small. It would be helpful to run the plugin against a variety of tenants to see if there are performance issues/parsing problems, etc.
- It doesn't seem like there is a convention for `logging` with plugins, so we are printing to console.
- It would be really neat to have this render in the web UI somehow. I included JSONL output so this might be easier in the future.
- Currently, the timeline output column names are prefixed with an underscore (ie, `_timestamp_column`) and do not match the naming convention for `log2timeline`. This would be an easy change if literal interoperability between ROADtools and `log2timeline` is desired.
- If this is merged, someone should add some usage instructions to the wiki.

I think that about sums it up! I hope others find this useful. Please let me know if you have any questions/issues and I will address them.

Thanks for all your work on ROADtools!! It rocks.

Ryan Marcotte Cobb