### PR TITLE
Remove "Assigned application roles" panel since it's broken and duplicate

### DIFF
--- a/roadrecon/frontend/src/app/appmain/serviceprincipals/serviceprincipalsdialog/serviceprincipalsdialog.component.html
+++ b/roadrecon/frontend/src/app/appmain/serviceprincipals/serviceprincipalsdialog/serviceprincipalsdialog.component.html
@@ -75,25 +75,6 @@
         <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
       </table>
     </mat-expansion-panel>
-    <mat-expansion-panel expanded>
-      <mat-expansion-panel-header>
-        <mat-panel-title>
-          Assigned application roles ({{ sp.appRolesAssigned.length }})
-        </mat-panel-title>
-      </mat-expansion-panel-header>
-      <table *ngIf="sp.appRolesAssigned.length > 0" mat-table [dataSource]="sp.appRolesAssigned">
-        <ng-container matColumnDef="displayName">
-          <th mat-header-cell *matHeaderCellDef>displayName</th>
-          <td mat-cell *matCellDef="let row">{{row.displayName}}</td>
-        </ng-container>
-        <ng-container matColumnDef="description">
-          <th mat-header-cell *matHeaderCellDef>Description</th>
-          <td mat-cell *matCellDef="let row">{{row.description}}</td>
-        </ng-container>
-        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-      </table>
-    </mat-expansion-panel>
     </mat-tab>
 
   <mat-tab label="Application roles assigned to others" *ngIf="sp.appRolesAssigned.length > 0">


### PR DESCRIPTION
Indeed this info is already shown in the "Application roles assigned to others" tab just right to it. Where the info is properly shown contrary to here. So let's clean this

Before, I was surprised by this empty area and wanted to fix it:
![image](https://user-images.githubusercontent.com/550823/208119111-ca2a84d4-981b-41f3-9644-0c7fa2ca6f48.png)
Except that I discovered that this data is already shown in this tab where it's properly displayed:
![image](https://user-images.githubusercontent.com/550823/208119187-3bebbea2-0460-4d0d-8162-85c2a95d3338.png)

So let's clean it (easy fix lol) which gives:
![image](https://user-images.githubusercontent.com/550823/208119220-6a296387-6bd9-4e31-9438-4ecf5eaf6f34.png)
