### PR TITLE
Fixed timeformat, by parsing time as string before passing it to jsonify

### DIFF
--- a/roadrecon/roadtools/roadrecon/server.py
+++ b/roadrecon/roadtools/roadrecon/server.py
@@ -363,7 +363,7 @@ def get_oauth2permissions():
         grant['targetspobjectid'] = targetapp.objectId
         grant['sourceapplication'] = rsp.displayName
         grant['sourcespobjectid'] = rsp.objectId
-        grant['expiry'] = permgrant.expiryTime
+        grant['expiry'] = permgrant.expiryTime.strftime("%Y-%m-%dT%H:%M:%S")
         grant['scope'] = permgrant.scope
         oauth2permissions.append(grant)
     return jsonify(oauth2permissions)


### PR DESCRIPTION
This fixes the issue described in #56 by passing the time to jsonify as a string instead of a datetime object.