### PR TITLE
User-friendly authentication errors

### DIFF
--- a/roadlib/roadtools/roadlib/auth.py
+++ b/roadlib/roadtools/roadlib/auth.py
@@ -1054,46 +1054,51 @@ class Authentication():
         Get tokens based on the arguments specified.
         Expects args to be generated from get_sub_argparse
         """
-        if self.tokendata:
-            return self.tokendata
-        if self.refresh_token and not self.access_token:
-            if self.refresh_token == 'file':
-                with codecs.open(args.tokenfile, 'r', 'utf-8') as infile:
-                    token_data = json.load(infile)
-            else:
-                token_data = {'refreshToken': self.refresh_token}
-            return self.authenticate_with_refresh_native(token_data['refreshToken'])
-        if self.access_token and not self.refresh_token:
-            self.tokendata, _ = self.parse_accesstoken(self.access_token)
-            return self.tokendata
-        if self.username and self.password:
-            return self.authenticate_username_password()
-        if args.as_app and self.password:
-            return self.authenticate_as_app()
-        if args.device_code:
-            return self.authenticate_device_code()
-        if args.prt_init:
-            nonce = self.get_prt_cookie_nonce()
-            if nonce:
-                print(f'Requested nonce from server to use with ROADtoken: {nonce}')
-            return False
-        if args.prt_cookie:
-            derived_key = self.ensure_binary_derivedkey(args.derived_key)
-            context = self.ensure_binary_context(args.prt_context)
-            sessionkey = self.ensure_binary_sessionkey(args.prt_sessionkey)
-            return self.authenticate_with_prt_cookie(args.prt_cookie, context, derived_key, args.prt_verify, sessionkey)
-        if args.prt and args.prt_context and args.derived_key:
-            derived_key = self.ensure_binary_derivedkey(args.derived_key)
-            context = self.ensure_binary_context(args.prt_context)
-            prt = self.ensure_plain_prt(args.prt)
-            return self.authenticate_with_prt(prt, context, derived_key=derived_key)
-        if args.prt and args.prt_sessionkey:
-            prt = self.ensure_plain_prt(args.prt)
-            sessionkey = self.ensure_binary_sessionkey(args.prt_sessionkey)
-            if args.kdf_v1:
-                return self.authenticate_with_prt(prt, None, sessionkey=sessionkey)
-            else:
-                return self.authenticate_with_prt_v2(prt, sessionkey)
+        try:
+            if self.tokendata:
+                return self.tokendata
+            if self.refresh_token and not self.access_token:
+                if self.refresh_token == 'file':
+                    with codecs.open(args.tokenfile, 'r', 'utf-8') as infile:
+                        token_data = json.load(infile)
+                else:
+                    token_data = {'refreshToken': self.refresh_token}
+                return self.authenticate_with_refresh_native(token_data['refreshToken'])
+            if self.access_token and not self.refresh_token:
+                self.tokendata, _ = self.parse_accesstoken(self.access_token)
+                return self.tokendata
+            if self.username and self.password:
+                return self.authenticate_username_password()
+            if args.as_app and self.password:
+                return self.authenticate_as_app()
+            if args.device_code:
+                return self.authenticate_device_code()
+            if args.prt_init:
+                nonce = self.get_prt_cookie_nonce()
+                if nonce:
+                    print(f'Requested nonce from server to use with ROADtoken: {nonce}')
+                return False
+            if args.prt_cookie:
+                derived_key = self.ensure_binary_derivedkey(args.derived_key)
+                context = self.ensure_binary_context(args.prt_context)
+                sessionkey = self.ensure_binary_sessionkey(args.prt_sessionkey)
+                return self.authenticate_with_prt_cookie(args.prt_cookie, context, derived_key, args.prt_verify, sessionkey)
+            if args.prt and args.prt_context and args.derived_key:
+                derived_key = self.ensure_binary_derivedkey(args.derived_key)
+                context = self.ensure_binary_context(args.prt_context)
+                prt = self.ensure_plain_prt(args.prt)
+                return self.authenticate_with_prt(prt, context, derived_key=derived_key)
+            if args.prt and args.prt_sessionkey:
+                prt = self.ensure_plain_prt(args.prt)
+                sessionkey = self.ensure_binary_sessionkey(args.prt_sessionkey)
+                if args.kdf_v1:
+                    return self.authenticate_with_prt(prt, None, sessionkey=sessionkey)
+                else:
+                    return self.authenticate_with_prt_v2(prt, sessionkey)
+
+        except adal.adal_error.AdalError as ex:
+            print(ex.error_response['error_description'])
+
         # If we are here, no auth to try
         print('Not enough information was supplied to authenticate')
         return False


### PR DESCRIPTION
This code adds a bit of exception handling around the various authentication options to parse the error returned by Microsoft and display it in a user-friendly format (instead of a stack trace) like so:

```
AADSTS50076: Due to a configuration change made by your administrator, or because you moved to a new location, you must use multi-factor authentication to access '00000002-0000-0ff1-ce00-000000000000'.
Trace ID: bfee79c7-0207-4e2c-a58b-14a16ad20300
Correlation ID: 1de9b66c-7cb3-4a30-9326-7b74319f6b63
Timestamp: 2023-06-23 10:16:39Z
Not enough information was supplied to authenticate
```