### PR TITLE
Encode pfx pass

### DIFF
--- a/roadtx/roadtools/roadtx/main.py
+++ b/roadtx/roadtools/roadtx/main.py
@@ -511,6 +511,9 @@ def main():
         if not args.secure:
             auth.verify = deviceauth.verify = False
 
+    if args.pfx_pass:
+        args.pfx_pass = args.pfx_pass.encode()
+
     if args.command in ('auth', 'gettokens', 'gettoken'):
         auth.parse_args(args)
         if not args.tokens_stdout:


### PR DESCRIPTION
Encode the pfx password the current version crash:

```
$ roadtx hybriddevice --sid S-1-5-21-<...> -t <...> --cert-pfx my.pfx --pfx-pass 'sdfdlsfjl'
Traceback (most recent call last):
 1 deviceauth.py +                                                                                                                                                                                                                          X 
  File "/usr/local/lib/python3.9/dist-packages/cryptography/utils.py", line 35, in _check_byteslike
    memoryview(value)
TypeError: memoryview: a bytes-like object is required, not 'str'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/roadtx", line 33, in <module>
    sys.exit(load_entry_point('roadtx==1.4.3', 'console_scripts', 'roadtx')())
  File "/usr/local/lib/python3.9/dist-packages/roadtx-1.4.3-py3.9.egg/roadtools/roadtx/main.py", line 548, in main
    if not deviceauth.loadcert(args.cert_pem, args.key_pem, args.cert_pfx, args.pfx_pass, args.pfx_base64):
  File "/usr/local/lib/python3.9/dist-packages/roadlib-0.19.1-py3.9.egg/roadtools/roadlib/deviceauth.py", line 79, in loadcert
    self.privkey, self.certificate, _ = pkcs12.load_key_and_certificates(pfxdata, pfxpass)
  File "/usr/local/lib/python3.9/dist-packages/cryptography/hazmat/primitives/serialization/pkcs12.py", line 154, in load_key_and_certificates
    return ossl.load_key_and_certificates_from_pkcs12(data, password)
 1 deviceauth.py +                                                                                                                                                                                                                          X 
  File "/usr/local/lib/python3.9/dist-packages/cryptography/hazmat/backends/openssl/backend.py", line 2177, in load_key_and_certificates_from_pkcs12
    pkcs12 = self.load_pkcs12(data, password)
 1 main.py +                                                                                                                                                                                                                                X 
  File "/usr/local/lib/python3.9/dist-packages/cryptography/hazmat/backends/openssl/backend.py", line 2188, in load_pkcs12
    utils._check_byteslike("password", password)
  File "/usr/local/lib/python3.9/dist-packages/cryptography/utils.py", line 37, in _check_byteslike
    raise TypeError("{} must be bytes-like".format(name))
TypeError: password must be bytes-like

```