### PR TITLE
Fix textual sqlalchemy query to explicitly call text()

### DIFF
--- a/roadrecon/roadtools/roadrecon/gather.py
+++ b/roadrecon/roadtools/roadrecon/gather.py
@@ -22,7 +22,7 @@ from roadtools.roadlib.metadef.database import (
     lnk_group_member_group, lnk_group_member_serviceprincipal,
     lnk_group_member_user, lnk_group_owner_serviceprincipal,
     lnk_group_owner_user)
-from sqlalchemy import bindparam, func
+from sqlalchemy import bindparam, func, text
 from sqlalchemy.dialects.postgresql import insert as pginsert
 from sqlalchemy.orm import sessionmaker
 
@@ -551,7 +551,7 @@ async def run(args):
         # Delete existing links to make sure we start with clean data
         for table in database.Base.metadata.tables.keys():
             if table.startswith('lnk_'):
-                dbsession.execute("DELETE FROM {0}".format(table))
+                dbsession.execute(text("DELETE FROM {0}".format(table)))
         dbsession.query(ApplicationRef).delete()
         dbsession.query(RoleAssignment).delete()
         dbsession.query(EligibleRoleAssignment).delete()


### PR DESCRIPTION
When using the `--skip-first-phase` links are deleted in the database using a textual sqlalchemy query. It appears that those have been deprecated for a while and are throwing errors in more recent versions of sqlalchemy:

```
user@ubuntu:~$ roadrecon gather --skip-first-phase
Refreshed token
Traceback (most recent call last):
  File "/home/user/.local/bin/roadrecon", line 8, in <module>
    sys.exit(main())
  File "/home/user/.local/lib/python3.10/site-packages/roadtools/roadrecon/main.py", line 120, in main
    gathermain(args)
  File "/home/user/.local/lib/python3.10/site-packages/roadtools/roadrecon/gather.py", line 715, in main
    loop.run_until_complete(run(args))
  File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/home/user/.local/lib/python3.10/site-packages/roadtools/roadrecon/gather.py", line 554, in run
    dbsession.execute("DELETE FROM {0}".format(table))
  File "/home/user/.local/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 2306, in execute
    return self._execute_internal(
  File "/home/user/.local/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 2086, in _execute_internal
    statement = coercions.expect(roles.StatementRole, statement)
  File "/home/user/.local/lib/python3.10/site-packages/sqlalchemy/sql/coercions.py", line 413, in expect
    resolved = impl._literal_coercion(
  File "/home/user/.local/lib/python3.10/site-packages/sqlalchemy/sql/coercions.py", line 638, in _literal_coercion
    return self._text_coercion(element, argname, **kw)
  File "/home/user/.local/lib/python3.10/site-packages/sqlalchemy/sql/coercions.py", line 631, in _text_coercion
    return _no_text_coercion(element, argname)
  File "/home/user/.local/lib/python3.10/site-packages/sqlalchemy/sql/coercions.py", line 601, in _no_text_coercion
    raise exc_cls(
sqlalchemy.exc.ArgumentError: Textual SQL expression 'DELETE FROM lnk_group_mem...' should be explicitly declared as text('DELETE FROM lnk_group_mem...')
```

According to the docs (https://docs.sqlalchemy.org/en/14/core/tutorial.html#using-textual-sql) the `text()` expression was already available in v 1.4, which is the minimum version installed by roadrecon (`roadrecon/setup.py` contains `'sqlalchemy>=1.4'`), so this change should not break anything.

