### PR TITLE
Add --port option to roadrecon gui

### DIFF
--- a/roadrecon/frontend/src/environments/environment.prod.ts
+++ b/roadrecon/frontend/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apibase: 'http://127.0.0.1:5000/api/'
+  apibase: '/api/'
 };

--- a/roadrecon/frontend/src/environments/environment.ts
+++ b/roadrecon/frontend/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  apibase: 'http://127.0.0.1:5000/api/'
+  apibase: '/api/'
 };
 
 /*

--- a/roadrecon/roadtools/roadrecon/main.py
+++ b/roadrecon/roadtools/roadrecon/main.py
@@ -65,6 +65,11 @@ def main():
     gui_parser.add_argument('--profile',
                             action='store_true',
                             help='Enable flask profiler')
+    gui_parser.add_argument('--port',
+                            type=int,
+                            action='store',
+                            help='HTTP Server port (default=5000)',
+                            default=5000)
 
     # Construct plugins module options
     plugin_parser = subparsers.add_parser('plugin', help='Run a ROADrecon plugin')

--- a/roadrecon/roadtools/roadrecon/server.py
+++ b/roadrecon/roadtools/roadrecon/server.py
@@ -572,6 +572,11 @@ def main(args=None):
         parser.add_argument('--profile',
                             action='store_true',
                             help='Enable flask profiler')
+        parser.add_argument('--port',
+                            type=int,
+                            action='store',
+                            help='HTTP Server port (default=5000)',
+                            default=5000)
         args = parser.parse_args()
     if not ':/' in args.database:
         if args.database[0] != '/':
@@ -584,7 +589,7 @@ def main(args=None):
     if args.profile:
         from werkzeug.middleware.profiler import ProfilerMiddleware
         app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[5])
-    app.run(debug=args.debug)
+    app.run(debug=args.debug, port=args.port)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Adding `--port` option to roadrecon gui in order to allow running the GUI on a different port than the current default 5000.

This change does not change current behavior. Simply running `roadrecon gui` will still launch the server on port 5000.

```
$ roadrecon gui
 * Serving Flask app 'roadtools.roadrecon.server'
 * Debug mode: off
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on http://127.0.0.1:5000
Press CTRL+C to quit
```

It does add the `--port` argument:

```diff
$ roadrecon gui --help
usage: roadrecon gui [-h] [-d DATABASE] [--debug] [--profile] [--port PORT]

options:
  -h, --help            show this help message and exit
  -d DATABASE, --database DATABASE
                        Database file. Can be the local database name for SQLite, or an SQLAlchemy compatible URL such as
                        postgresql+psycopg2://dirkjan@/roadtools
  --debug               Enable flask debug
  --profile             Enable flask profiler
+  --port PORT           HTTP Server port (default=5000)
```

Which allows running the GUI on another port:

```
 roadrecon gui --port 1337
 * Serving Flask app 'roadtools.roadrecon.server'
 * Debug mode: off
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on http://127.0.0.1:1337
Press CTRL+C to quit
```