### PR TITLE
Added the ability to override default user agent 

### DIFF
--- a/roadlib/roadtools/roadlib/deviceauth.py
+++ b/roadlib/roadtools/roadlib/deviceauth.py
@@ -64,6 +64,47 @@ class DeviceAuthentication():
         else:
             self.auth = Authentication()
 
+    def parse_args(self, args):
+        if hasattr(args,"os_version"):
+            self.os_version = args.os_version
+        if hasattr(args,"deviceticket"):
+            self.deviceticket = args.deviceticket
+        if hasattr(args,"name"):
+            self.device_name = args.name
+        if hasattr(args,"domain"):
+            self.domain = args.domain
+        if hasattr(args,"device_type"):
+            self.device_type = args.device_type
+        if hasattr(args,"user_agent"):
+            self.user_agent = args.user_agent
+            self.auth.user_agent = args.user_agent
+        if hasattr(args,"cert_pem"):
+            self.certout = args.cert_pem
+        if hasattr(args,"key_pem"):
+            self.privout = args.key_pem
+        if hasattr(args,"device_user_agent"):
+            self.device_user_agent = args.device_user_agent
+
+        if not hasattr(self,"device_user_agent") or self.device_user_agent is None:
+            self.device_user_agent = "Dsreg/10.0"
+
+        if not hasattr(self,"device_type") or self.device_type is None:
+            self.device_type = "Windows"
+
+        if not hasattr(self,"domain") or self.domain is None:
+            self.domain = "iminyour.cloud"
+
+        if not hasattr(self,"os_version") or self.os_version is None:
+            if self.device_type.lower() == "windows":
+                self.os_version = "10.0.19041.928"
+            elif self.device_type.lower() == "macos":
+                self.os_version = "12.2.0"
+            elif self.device_type.lower() == "android":
+                self.os_version = "13.0"
+
+        if not hasattr(self,"device_name") or self.device_name is None:
+            self.device_name = 'DESKTOP-' + ''.join(random.choices(string.ascii_uppercase + string.digits, k=8))
+
     def loadcert(self, pemfile=None, privkeyfile=None, pfxfile=None, pfxpass=None, pfxbase64=None):
         """
         Load a device certificate from disk
@@ -263,7 +304,7 @@ class DeviceAuthentication():
         headers = {
             'Authorization': f'Bearer {access_token}',
             'Content-Type': 'application/json',
-            'User-Agent': 'Dsreg/10.0 (Windows 10.0.19044.1826)',
+            'User-Agent': f'{self.device_user_agent} (Windows {self.os_version})',
             'Accept': 'application/json',
         }
         data = {
@@ -327,30 +368,16 @@ class DeviceAuthentication():
             }
         return json.dumps(jwk, separators=(',', ':'))
 
-    def register_device(self, access_token, jointype=0, certout=None, privout=None, device_type=None, device_name=None, os_version=None, deviceticket=None):
+    def register_device(self, access_token, jointype=0, certout=None, privout=None):
         """
         Registers or joins a device in Azure AD. Requires an access token to the device registration service.
         """
         # Fill in names if not supplied
-        if not device_name:
-            device_name = 'DESKTOP-' + ''.join(random.choices(string.ascii_uppercase + string.digits, k=8))
-
         if not certout:
-            certout = device_name.lower() + '.pem'
+            certout = self.device_name.lower() + '.pem'
 
         if not privout:
-            privout = device_name.lower() + '.key'
-
-        if not device_type:
-            device_type = "Windows"
-
-        if not os_version:
-            if device_type.lower() == "windows":
-                os_version = "10.0.19041.928"
-            elif device_type.lower() == "macos":
-                os_version = "12.2.0"
-            elif device_type.lower() == "android":
-                os_version = "13.0"
+            privout = self.device_name.lower() + '.key'
 
         # Generate our key
         key = rsa.generate_private_key(
@@ -378,22 +405,22 @@ class DeviceAuthentication():
         pubkeycngblob = base64.b64encode(self.create_pubkey_blob_from_key(key))
 
 
-        if device_type.lower() == 'macos':
+        if self.device_type.lower() == 'macos':
             data = {
-                "DeviceDisplayName" : device_name,
+                "DeviceDisplayName" : self.device_name,
                 "CertificateRequest" : {
                     "Type" : "pkcs10",
                     "Data" : certbytes.decode('utf-8')
                 },
-                "OSVersion" : os_version,
-                "TargetDomain" : "iminyour.cloud",
+                "OSVersion" : self.os_version,
+                "TargetDomain" : self.domain,
                 "AikCertificate" : "",
                 "DeviceType" : "MacOS",
                 "TransportKey" : base64.b64encode(self.create_public_jwk_from_key(key, True).encode('utf-8')).decode('utf-8'),
                 "JoinType" : jointype,
                 "AttestationData" : ""
             }
-        elif device_type.lower() == 'android':
+        elif self.device_type.lower() == 'android':
             data = {
                 "Attributes": {},
                 "CertificateRequest":
@@ -401,10 +428,10 @@ class DeviceAuthentication():
                     "Data": certbytes.decode('utf-8'),
                     "Type": "pkcs10"
                 },
-                "DeviceDisplayName": device_name,
+                "DeviceDisplayName": self.device_name,
                 "DeviceType": "Android",
                 "JoinType": jointype,
-                "OSVersion": os_version,
+                "OSVersion": self.os_version,
                 "TargetDomain": "6287f28f-4f7f-4322-9651-a8697d8fe1bc",
                 "TransportKey": base64.b64encode(self.create_public_jwk_from_key(key, True).encode('utf-8')).decode('utf-8'),
             }
@@ -417,10 +444,10 @@ class DeviceAuthentication():
                     },
                 "TransportKey": pubkeycngblob.decode('utf-8'),
                 # Can likely be edited to anything, are not validated afaik
-                "TargetDomain": "iminyour.cloud",
-                "DeviceType": device_type,
-                "OSVersion": os_version,
-                "DeviceDisplayName": device_name,
+                "TargetDomain": self.domain,
+                "DeviceType": self.device_type,
+                "OSVersion": self.os_version,
+                "DeviceDisplayName": self.device_name,
                 "JoinType": jointype,
                 "attributes": {
                     "ReuseDevice": "true",
@@ -428,8 +455,8 @@ class DeviceAuthentication():
                 }
             }
             # Add device ticket if requested
-            if deviceticket:
-                data['attributes']['MSA-DDID'] = base64.b64encode(deviceticket.encode('utf-8')).decode('utf-8')
+            if self.deviceticket:
+                data['attributes']['MSA-DDID'] = base64.b64encode(self.deviceticket.encode('utf-8')).decode('utf-8')
 
 
         headers = {
@@ -453,23 +480,15 @@ class DeviceAuthentication():
         print(f'Saved device certificate to {certout}')
         return True
 
-    def register_hybrid_device(self, objectsid, tenantid, certout=None, privout=None, device_type=None, device_name=None, os_version=None):
+    def register_hybrid_device(self, objectsid, tenantid, certout=None, privout=None):
         '''
         Register hybrid device. Requires existing key/cert to be already loaded and the SID to be specified.
         Device should be synced to AAD already, otherwise this will fail.
         '''
         # Fill in names if not supplied
-        if not device_name:
-            device_name = 'DESKTOP-' + ''.join(random.choices(string.ascii_uppercase + string.digits, k=8))
-
-        certout = device_name.lower() + '_aad.pem'
-        privout = device_name.lower() + '_aad.key'
-
-        if not device_type:
-            device_type = "Windows"
-
-        if not os_version:
-            os_version = "10.0.19041.928"
+        
+        certout = self.device_name.lower() + '_aad.pem'
+        privout = self.device_name.lower() + '_aad.key'
 
         # Generate our new shiny key
         key = rsa.generate_private_key(
@@ -512,10 +531,10 @@ class DeviceAuthentication():
             "ServerAdJoinData":
             {
                 "TransportKey": pubkeycngblob.decode('utf-8'),
-                "TargetDomain": "iminyour.cloud",
-                "DeviceType": device_type,
-                "OSVersion": os_version,
-                "DeviceDisplayName": device_name,
+                "TargetDomain": self.domain,
+                "DeviceType": self.device_type,
+                "OSVersion": self.os_version,
+                "DeviceDisplayName": self.device_name,
                 "TargetDomainId": f"{tenantid}",
                 "ClientIdentity":
                 {
@@ -533,7 +552,7 @@ class DeviceAuthentication():
         }
 
         headers = {
-            'User-Agent': f'Dsreg/10.0 (Windows {os_version})',
+            'User-Agent': f'{self.device_user_agent} ({self.device_type} {self.os_version})',
             'Content-Type': 'application/json'
         }
         # Extract device ID from certificate

--- a/roadlib/roadtools/roadlib/deviceauth.py
+++ b/roadlib/roadtools/roadlib/deviceauth.py
@@ -372,12 +372,12 @@ class DeviceAuthentication():
         """
         Registers or joins a device in Azure AD. Requires an access token to the device registration service.
         """
-        # For backward compatiblity "overwrite" already set arguments if they are provided
+        # For backward compatiblity fill arguments that are not provided from properties
         device_type = device_type or self.device_type
         device_name = device_name or self.device_name
         os_version = os_version or self.os_version
         deviceticket = deviceticket or self.deviceticket
-        
+
         # Fill in names if not supplied
         if not certout:
             certout = device_name.lower() + '.pem'
@@ -491,7 +491,7 @@ class DeviceAuthentication():
         Register hybrid device. Requires existing key/cert to be already loaded and the SID to be specified.
         Device should be synced to AAD already, otherwise this will fail.
         '''
-        # For backward compatiblity "overwrite" already set arguments if they are provided
+        # For backward compatiblity fill arguments that are not provided from properties
         device_type = device_type or self.device_type
         device_name = device_name or self.device_name
         os_version = os_version or self.os_version

--- a/roadtx/roadtools/roadtx/main.py
+++ b/roadtx/roadtools/roadtx/main.py
@@ -76,10 +76,15 @@ def main():
     device_parser.add_argument('-c', '--cert-pem', action='store', metavar='file', help='Certificate file to save device cert to (default: <devicename>.pem)')
     device_parser.add_argument('-k', '--key-pem', action='store', metavar='file', help='Private key file for certificate (default: <devicename>.key)')
     device_parser.add_argument('-n', '--name', action='store', help='Device display name (default: DESKTOP-<RANDOM>)')
+    device_parser.add_argument('-d','--domain',action='store',help='Target domain to join to (default: iminyour.cloud)')
     device_parser.add_argument('--access-token', action='store', help='Access token for device registration service. If not specified, taken from .roadtools_auth')
     device_parser.add_argument('--device-type', action='store', help='Device OS type (default: Windows)')
     device_parser.add_argument('--os-version', action='store', help='Device OS version (default: 10.0.19041.928)')
     device_parser.add_argument('--deviceticket', action='store', help='Device MSA ticket to match with existing device')
+    device_parser.add_argument('-dua', '--device-user-agent', action='store',
+                                help='Custom device user agent to use. Default: Dsreg/10.0')
+    device_parser.add_argument('-ua', '--user-agent', action='store',
+                                help='Custom request user agent to use. Default: Python requests user agent')
 
     # Construct hybrid device module
     hdevice_parser = subparsers.add_parser('hybriddevice', help='Join an on-prem device to Azure AD')
@@ -89,10 +94,15 @@ def main():
     hdevice_parser.add_argument('--pfx-pass', action='store', metavar='password', help='PFX file password')
     hdevice_parser.add_argument('--pfx-base64', action='store', metavar='BASE64', help='PFX file as base64 string')
     hdevice_parser.add_argument('-n', '--name', action='store', help='Device display name (default: DESKTOP-<RANDOM>)')
+    hdevice_parser.add_argument('-d','--domain',action='store',help='Target domain to join to (default: iminyour.cloud)')
     hdevice_parser.add_argument('--device-type', action='store', help='Device OS type (default: Windows)')
     hdevice_parser.add_argument('--os-version', action='store', help='Device OS version (default: 10.0.19041.928)')
     hdevice_parser.add_argument('--sid', action='store', required=True, help='Device SID in AD')
     hdevice_parser.add_argument('-t', '--tenant', action='store', required=True, help='Tenant ID where device exists')
+    hdevice_parser.add_argument('-dua', '--device-user-agent', action='store',
+                                help='Custom device user agent to use. Default: Dsreg/10.0')
+    hdevice_parser.add_argument('-ua', '--user-agent', action='store',
+                                help='Custom user agent to use. Default: Python requests user agent')
 
     # Construct PRT module
     prt_parser = subparsers.add_parser('prt', help='PRT request/renewal module')
@@ -121,6 +131,8 @@ def main():
     prt_parser.add_argument('-s', '--prt-sessionkey', action='store', help='Primary Refresh Token session key (as hex key)')
 
     prt_parser.add_argument('-hk', '--hello-key', action='store', help='Windows Hello PEM file')
+    prt_parser.add_argument('-ua', '--user-agent', action='store',
+                                help='Custom user agent to use. Default: Python requests user agent')
     # Construct winhello module
     winhello_parser = subparsers.add_parser('winhello', help='Register Windows Hello key')
     winhello_parser.add_argument('-k', '--key-pem', action='store', metavar='file', help='Private key file for key storage (default: winhello.key)')
@@ -255,6 +267,8 @@ def main():
     codeauth_parser.add_argument('code',
                                  action='store',
                                  help="Code to auth with that you got from Azure AD")
+    codeauth_parser.add_argument('-ua', '--user-agent', action='store',
+                                help='Custom user agent to use. Default: Python requests user agent')
 
     # Bulk enrollment token
     bulkenrollment_parser = subparsers.add_parser('bulkenrollmenttoken', help='Request / use bulk enrollment tokens')
@@ -639,8 +653,9 @@ def main():
         sys.exit(1)
         return
 
-    deviceauth = DeviceAuthentication(auth)
     args = parser.parse_args()
+    deviceauth = DeviceAuthentication(auth)
+    deviceauth.parse_args(args)
     seleniumproxy = None
 
     if args.proxy:
@@ -737,7 +752,7 @@ def main():
                 jointype = 0
             else:
                 jointype = 4
-            deviceauth.register_device(tokenobject['accessToken'], jointype=jointype, certout=args.cert_pem, privout=args.key_pem, device_type=args.device_type, device_name=args.name, os_version=args.os_version, deviceticket=args.deviceticket)
+            deviceauth.register_device(tokenobject['accessToken'], jointype=jointype, certout=args.cert_pem, privout=args.key_pem)
         elif args.action == 'delete':
             if not deviceauth.loadcert(args.cert_pem, args.key_pem):
                 return
@@ -745,7 +760,7 @@ def main():
     elif args.command == 'hybriddevice':
         if not deviceauth.loadcert(args.cert_pem, args.key_pem, args.cert_pfx, args.pfx_pass, args.pfx_base64):
             return
-        deviceauth.register_hybrid_device(args.sid, args.tenant, certout=args.cert_pem, privout=args.key_pem, device_type=args.device_type, device_name=args.name, os_version=args.os_version)
+        deviceauth.register_hybrid_device(args.sid, args.tenant, certout=args.cert_pem, privout=args.key_pem)
     elif args.command == 'prt':
         if args.action == 'request':
             if not deviceauth.loadcert(args.cert_pem, args.key_pem, args.cert_pfx, args.pfx_pass, args.pfx_base64):
@@ -853,6 +868,7 @@ def main():
     elif args.command == 'codeauth':
         auth.set_client_id(args.client)
         auth.set_resource_uri(args.resource)
+        auth.set_user_agent(args.user_agent)
         auth.tenant = args.tenant
         if args.cae:
             auth.use_cae = args.cae


### PR DESCRIPTION
Added the ability to override default user agent in multiple flows:

- PRT
- Code Auth
- Device
- Hybrid Device

Additionally it's possible to overwrite the target domain in the device module.