### PR TITLE
Handles case of grace period for registering MFA

### DIFF
--- a/roadtx/roadtools/roadtx/selenium.py
+++ b/roadtx/roadtools/roadtx/selenium.py
@@ -160,6 +160,16 @@ class SeleniumAuthentication():
                 els = WebDriverWait(driver, 6000).until(lambda d: d.find_element(By.ID, "i0118"))
                 els.send_keys(Keys.ENTER)
 
+        try:
+            # handle case with "Action Required"
+            # happens when user is not registered with MFA yet and has XX days until required
+            els = WebDriverWait(driver, 2).until(lambda d: d.find_element(By.ID, 'txtSkipMfaRegistration'))
+            print(f"MFA will be enforced for this account: {els.text} (skipping now)")
+            els = WebDriverWait(driver, 2).until(lambda d: d.find_element(By.ID, 'btnAskLater'))
+            els.click()
+        except TimeoutException:
+            pass
+        
         # Quick check of mfa not needed
         try:
             WebDriverWait(driver, 2).until(lambda d: '?code=' in d.current_url)


### PR DESCRIPTION
Hello,

love the tool, thanks for sharing. When doing some tests, especially with brand new users I get into this case when user is required to register for MFA (<14 days grace period) but is not registered yet. With this code change, selenium would click the "Ask later" button to skip registration. 

![Screenshot 2024-08-16 145811](https://github.com/user-attachments/assets/3881381d-118d-4062-b717-f91abc08318f)
