### PR TITLE
Add --origin Argument for Handling Single Page Application Refresh Tokens

### DIFF
--- a/roadlib/roadtools/roadlib/auth.py
+++ b/roadlib/roadtools/roadlib/auth.py
@@ -45,6 +45,7 @@ class Authentication():
         self.password = password
         self.tenant = tenant
         self.client_id = None
+        self.origin = None
         self.set_client_id(client_id)
         self.resource_uri = 'https://graph.windows.net/'
         self.tokendata = {}
@@ -78,6 +79,12 @@ class Authentication():
         Sets client ID to use (accepts aliases)
         """
         self.client_id = self.lookup_client_id(clid)
+
+    def set_origin_value(self, origin):
+        """
+        Sets Origin header to use
+        """
+        self.origin = origin
 
     def set_resource_uri(self, uri):
         """
@@ -1215,6 +1222,9 @@ class Authentication():
         auth_parser.add_argument('--refresh-token',
                                  action='store',
                                  help='Refresh token (or the word "file" to read it from .roadtools_auth)')
+        auth_parser.add_argument('--origin',
+                                 action='store',
+                                 help='Origin of a browser refresh token like "https://portal.azure.com". Used with Azure portal or other portal refresh tokens when combind with a client id like -c c44b4083-3bb0-49c1-b47d-974e53cbdf3c.')
         auth_parser.add_argument('--saml-token',
                                  action='store',
                                  help='SAML token from Federation Server')
@@ -1449,6 +1459,11 @@ class Authentication():
             headers = kwargs.get('headers',{})
             headers['User-Agent'] = self.user_agent
             kwargs['headers'] = headers
+        if self.origin:
+            #self.set_client_id('c44b4083-3bb0-49c1-b47d-974e53cbdf3c') This is the portal.azure.com default client id
+            headers = kwargs.get('headers',{})
+            headers['Origin'] = self.origin
+            kwargs['headers'] = headers
         return requests.post(*args, timeout=30.0, **kwargs)
 
     def parse_args(self, args):
@@ -1458,6 +1473,7 @@ class Authentication():
         self.set_client_id(args.client)
         self.access_token = args.access_token
         self.refresh_token = args.refresh_token
+        self.set_origin_value(args.origin)
         self.saml_token = args.saml_token
         self.outfile = args.tokenfile
         self.debug = args.debug

--- a/roadlib/roadtools/roadlib/auth.py
+++ b/roadlib/roadtools/roadlib/auth.py
@@ -493,6 +493,8 @@ class Authentication():
         }
         if client_secret:
             data['client_secret'] = client_secret
+        if self.client_id == "c44b4083-3bb0-49c1-b47d-974e53cbdf3c":
+            self.set_origin_value("https://portal.azure.com")
         if additionaldata:
             data = {**data, **additionaldata}
         res = self.requests_post(f"{authority_uri}/oauth2/token", data=data)
@@ -521,6 +523,8 @@ class Authentication():
         }
         if client_secret:
             data['client_secret'] = client_secret
+        if self.client_id == "c44b4083-3bb0-49c1-b47d-974e53cbdf3c":
+            self.set_origin_value("https://portal.azure.com")
         if self.use_cae:
             data['claims'] = '{"access_token":{"xms_cc":{"values":["cp1"]}}}'
         if additionaldata:

--- a/roadrecon/roadtools/roadrecon/gather.py
+++ b/roadrecon/roadtools/roadrecon/gather.py
@@ -126,12 +126,10 @@ def checktoken():
             auth.set_user_agent(token['useragent'])
         if 'refreshToken' in token:
             #token = auth.authenticate_with_refresh(token)
-            try {
+            try:
                 token = auth.authenticate_with_refresh_native(token['refreshToken'])
-            }
-            except {
-                token = auth.authenticate_with_refresh_native_v2(['refreshToken'])
-            }
+            except:
+                token = auth.authenticate_with_refresh_native_v2(token['refreshToken'])
             headers['Authorization'] = '%s %s' % (token['tokenType'], token['accessToken'])
             expiretime = time.time() + token['expiresIn']
             print('Refreshed token')

--- a/roadrecon/roadtools/roadrecon/gather.py
+++ b/roadrecon/roadtools/roadrecon/gather.py
@@ -125,18 +125,14 @@ def checktoken():
         auth.tokendata = token
         if 'useragent' in token:
             auth.set_user_agent(token['useragent'])
+        if 'originheader' in token:
+            auth.set_origin_value(token['originheader'])
         if 'refreshToken' in token:
-            print("+ Attempting token refresh +")
-            #token = auth.authenticate_with_refresh(token)
-            try:
-                token = auth.authenticate_with_refresh_native(token['refreshToken'])
-            except:
-                token = auth.authenticate_with_refresh_native_v2(token['refreshToken'])
+            print("- Attempting token refresh -")
+            token = auth.authenticate_with_refresh(token)
             headers['Authorization'] = '%s %s' % (token['tokenType'], token['accessToken'])
-            #expiretime = time.time() + token['expiresIn']
-            dt = datetime.strptime(token['expiresOn'], "%Y-%m-%d %H:%M:%S")
-            expiretime = dt.timestamp()
-            print('Refreshed token')
+            expiretime = time.time() + token['expiresIn']
+            print('+ Refreshed token +')
             return True
         elif time.time() > expiretime:
             print('Access token is expired, but no access to refresh token! Dumping will fail')

--- a/roadrecon/roadtools/roadrecon/gather.py
+++ b/roadrecon/roadtools/roadrecon/gather.py
@@ -116,6 +116,7 @@ async def ratelimit():
 def checktoken():
     global token, expiretime
     if time.time() > expiretime - 300:
+        print("+ Attempting token refresh +")
         auth = Authentication()
         try:
             auth.client_id = token['_clientId']

--- a/roadrecon/roadtools/roadrecon/gather.py
+++ b/roadrecon/roadtools/roadrecon/gather.py
@@ -125,7 +125,13 @@ def checktoken():
         if 'useragent' in token:
             auth.set_user_agent(token['useragent'])
         if 'refreshToken' in token:
-            token = auth.authenticate_with_refresh(token)
+            #token = auth.authenticate_with_refresh(token)
+            try {
+                token = auth.authenticate_with_refresh_native(token['refreshToken'])
+            }
+            except {
+                token = auth.authenticate_with_refresh_native_v2(['refreshToken'])
+            }
             headers['Authorization'] = '%s %s' % (token['tokenType'], token['accessToken'])
             expiretime = time.time() + token['expiresIn']
             print('Refreshed token')

--- a/roadrecon/roadtools/roadrecon/gather.py
+++ b/roadrecon/roadtools/roadrecon/gather.py
@@ -25,6 +25,7 @@ from roadtools.roadlib.metadef.database import (
 from sqlalchemy import bindparam, func, text
 from sqlalchemy.dialects.postgresql import insert as pginsert
 from sqlalchemy.orm import sessionmaker
+from datetime import datetime
 
 warnings.simplefilter('ignore')
 token = None
@@ -131,7 +132,9 @@ def checktoken():
             except:
                 token = auth.authenticate_with_refresh_native_v2(token['refreshToken'])
             headers['Authorization'] = '%s %s' % (token['tokenType'], token['accessToken'])
-            expiretime = time.time() + token['expiresIn']
+            #expiretime = time.time() + token['expiresIn']
+            dt = datetime.strptime(token['expiresOn'], "%Y-%m-%d %H:%M:%S")
+            expiretime = dt.timestamp()
             print('Refreshed token')
             return True
         elif time.time() > expiretime:

--- a/roadrecon/roadtools/roadrecon/gather.py
+++ b/roadrecon/roadtools/roadrecon/gather.py
@@ -116,7 +116,6 @@ async def ratelimit():
 def checktoken():
     global token, expiretime
     if time.time() > expiretime - 300:
-        print("+ Attempting token refresh +")
         auth = Authentication()
         try:
             auth.client_id = token['_clientId']
@@ -127,6 +126,7 @@ def checktoken():
         if 'useragent' in token:
             auth.set_user_agent(token['useragent'])
         if 'refreshToken' in token:
+            print("+ Attempting token refresh +")
             #token = auth.authenticate_with_refresh(token)
             try:
                 token = auth.authenticate_with_refresh_native(token['refreshToken'])


### PR DESCRIPTION
This pull requests includes updates to roadlib's auth.py and roadrecon's gather.py. The changes add the argument --origin which appends a header origin value to refresh token requests which is required when using Single Page Application (SPA) refresh tokens such as the Azure portal or Office Online Application portal. Users obtain a refresh token from an authenticated browser session, supply the SPA client-id, and pass an '--origin' value such as 'https://portal.azure.com' so they can then obtain an access token. Example syntax when using a refresh token from the Azure portal : roadtx gettokens -c c44b4083-3bb0-49c1-b47d-974e53cbdf3c --origin "https://portal.azure.com" --refresh-token "<portal refresh token>"

These changes have been tested and allow running collections and obtaining tokens in hardened Azure environments where device-code flow, external applications, and Selenium browser implementations are not an option. Obtaining refresh tokens from a user's authenticated browser session logged into one of the portals and supplying it to obtain an access token makes for a simple and efficient workflow. The checktoken function of gather.py was modified to handle requesting a new token with the appropriate origin header value for collections in large tenants.