### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ cd roadrecon/frontend/
 npm install
 ```
 
-You can run the Angular frontend with `npm start` or `ng serve` using the Angular CLI from the `roadrecon/frontend/` directory. To build the JavaScript files into ROADrecon's `dist_gui` directory, run `npm build`.
+You can run the Angular frontend with `npm start` or `ng serve` using the Angular CLI from the `roadrecon/frontend/` directory. To build the JavaScript files into ROADrecon's `dist_gui` directory, run `npm run build`.
 
 ### Using ROADrecon
 See [this Wiki page](https://github.com/dirkjanm/ROADtools/wiki/Getting-started-with-ROADrecon) on how to get started.


### PR DESCRIPTION
fix npm build syntax

```
npm build
Unknown command: "build"

Did you mean this?
    npm run build # run the "build" package script

To see a list of supported npm commands, run:
  npm help
  ```
  
  
  ```
  npm run build

> roadrecon@0.0.0 build
> ng build

✔ Browser application bundle generation complete.
✔ Copying assets complete.
✔ Index html generation complete.
```