### PR TITLE
save_tokens fix error in case origin arg is not set

### DIFF
--- a/roadlib/roadtools/roadlib/auth.py
+++ b/roadlib/roadtools/roadlib/auth.py
@@ -1579,9 +1579,9 @@ class Authentication():
         return False
 
     def save_tokens(self, args):
-        if args.origin:
+        if hasattr(args, 'origin') and args.origin:
             self.tokendata['originheader'] = args.origin
-        if args.tokens_stdout:
+        if hasattr(args, 'tokens_stdout') and args.tokens_stdout:
             sys.stdout.write(json.dumps(self.tokendata))
         else:
             with codecs.open(self.outfile, 'w', 'utf-8') as outfile:


### PR DESCRIPTION
Some commands/modules might not set the `origin` argument introduced in #99. This could cause the following error.

```
Traceback (most recent call last):
  File "/home/csandker/01-tools/ROADtools/venv/bin/roadtx", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/csandker/01-tools/ROADtools/venv/lib/python3.12/site-packages/roadtools/roadtx/main.py", line 1054, in main
    auth.save_tokens(args)
  File "/home/csandker/01-tools/ROADtools/venv/lib/python3.12/site-packages/roadtools/roadlib/auth.py", line 1582, in save_tokens
    if args.origin:
       ^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'origin'
```

Fixed by checking if attribute is set on the `args` object.