### PR TITLE
Update firstpartyscopes.json

### DIFF
--- a/roadtx/roadtools/roadtx/firstpartyscopes.json
+++ b/roadtx/roadtools/roadtx/firstpartyscopes.json
@@ -112,6 +112,9 @@
                 "cc15fd57-2c6c-4117-a88c-83b1d56b4bbe": [
                     "Authorization.ReadWrite",
                     "user_impersonation"
+                ],
+                "499b84ac-1321-427f-aa17-267ca6975798":[
+                    "user_impersonation"
                 ]
             }
         },
@@ -402,6 +405,9 @@
                 ],
                 "cc15fd57-2c6c-4117-a88c-83b1d56b4bbe": [
                     "Authorization.ReadWrite",
+                    "user_impersonation"
+                ],
+                "499b84ac-1321-427f-aa17-267ca6975798":[
                     "user_impersonation"
                 ]
             }
@@ -2083,6 +2089,9 @@
                 "e1979c22-8b73-4aed-a4da-572cc4d0b832": [
                     "AppDefinitions.ReadWrite",
                     "Cards.ReadWrite"
+                ],
+                "499b84ac-1321-427f-aa17-267ca6975798":[
+                    "user_impersonation"
                 ]
             }
         },
@@ -3009,6 +3018,9 @@
                 ],
                 "fe053c5f-3692-4f14-aef2-ee34fc081cae": [
                     "Runtime.All"
+                ],
+                "499b84ac-1321-427f-aa17-267ca6975798":[
+                    "user_impersonation"
                 ]
             }
         },


### PR DESCRIPTION
Added Azure DevOPS scope for the following clients: 

d3590ed6-52b3-4102-aeff-aad2292ab01c,Microsoft Office 
872cd9fa-d31f-45e0-9eab-6e460a02d1f1,Visual Studio 
04b07795-8ddb-461a-bbee-02f9e1bf7b46,Microsoft Azure CLI 
1950a258-227b-4e31-a9cf-717495945fc2,Microsoft Azure PowerShell

Switch from any foci client to azure devops using: roadtx refreshtokento -c 1950a258-227b-4e31-a9cf-717495945fc2  -r '499b84ac-1321-427f-aa17-267ca6975798/.default'