### PR TITLE
Update auth.py to fix the decoding process of tokenreply

### DIFF
--- a/roadlib/roadtools/roadlib/auth.py
+++ b/roadlib/roadtools/roadlib/auth.py
@@ -1469,7 +1469,7 @@ class Authentication():
             tokenobject['expiresOn'] = (datetime.datetime.now() + datetime.timedelta(seconds=int(tokenreply['expires_in']))).strftime('%Y-%m-%d %H:%M:%S')
 
         tokenparts = tokenreply['access_token'].split('.')
-        inputdata = json.loads(base64.b64decode(tokenparts[1]+('='*(len(tokenparts[1])%4))))
+        inputdata = json.loads(base64.urlsafe_b64decode(tokenparts[1]+('='*(len(tokenparts[1])%4))))
         try:
             tokenobject['tenantId'] = inputdata['tid']
         except KeyError:


### PR DESCRIPTION
The tokenreply is Base64URL encoded data, not Base64 encoded, so urlsafe_b64decode should be used for decoding.
ref: https://datatracker.ietf.org/doc/html/rfc7515#section-7.1