### PR TITLE
Add default os_version value to prevent failure if unset 

### DIFF
--- a/roadlib/roadtools/roadlib/asyncdeviceauth.py
+++ b/roadlib/roadtools/roadlib/asyncdeviceauth.py
@@ -123,6 +123,8 @@ class AsyncDeviceAuthentication(DeviceAuthentication):
                 os_version = "14.5.0"
             elif device_type.lower() == "android":
                 os_version = "13.0"
+            else:
+                os_version = "1"
 
         if not device_domain:
             device_domain = "iminyour.cloud"

--- a/roadlib/roadtools/roadlib/deviceauth.py
+++ b/roadlib/roadtools/roadlib/deviceauth.py
@@ -375,6 +375,8 @@ class DeviceAuthentication():
                 os_version = "14.5.0"
             elif device_type.lower() == "android":
                 os_version = "13.0"
+            else:
+                os_version = "1"
 
         if not device_domain:
             device_domain = "iminyour.cloud"


### PR DESCRIPTION
If a non-standard device is created and the os_version is not set device add with `roadtx device -a join` will fail because os_version is None. Added default value of 1 to prevent failure. 