### PR TITLE
roadrecon: specify dependencies for plugin road2timeline

### DIFF
--- a/roadrecon/setup.py
+++ b/roadrecon/setup.py
@@ -30,6 +30,9 @@ setup(name='roadrecon',
           'aiohttp',
           'openpyxl'
       ],
+      extras_require={
+          'road2timeline': ['pyyaml', 'numpy', 'pandas']
+      },
       zip_safe=False,
       include_package_data=True,
       entry_points={


### PR DESCRIPTION
This allows to install roadrecon including dependencies for plugins (e.g. `pipx install roadrecon[road2timeline]`).

> `extras_require`
> A dictionary mapping names of “extras” (optional features of your project) to strings or lists of strings specifying what other distributions must be installed to support those features. See the section on [Declaring required dependency](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#declaring-dependencies) for details and examples of the format of this argument.

Source: https://setuptools.pypa.io/en/latest/references/keywords.html