### PR TITLE
Failure on Attempting refresh token when doing roadrecon gather

### DIFF
--- a/roadrecon/roadtools/roadrecon/gather.py
+++ b/roadrecon/roadtools/roadrecon/gather.py
@@ -131,7 +131,7 @@ def checktoken():
             print("- Attempting token refresh -")
             token = auth.authenticate_with_refresh(token)
             headers['Authorization'] = '%s %s' % (token['tokenType'], token['accessToken'])
-            expiretime = time.time() + token['expiresIn']
+            expiretime = time.time() + float(token['expiresIn'])
             print('+ Refreshed token +')
             return True
         elif time.time() > expiretime:


### PR DESCRIPTION
in gather.py line 134, the code is doing unsupported operand type(s) for +: 'float' and 'str'.

By changing the code to be in float type. The issue is resolved