### PR TITLE
Add `--host` option to roadrecon gui for custom binding (e.g. `0.0.0.0`)

### DIFF
--- a/roadrecon/roadtools/roadrecon/main.py
+++ b/roadrecon/roadtools/roadrecon/main.py
@@ -54,34 +54,27 @@ def main():
 
     # Construct GUI options
     gui_parser = subparsers.add_parser('gui', help='Launch the web-based GUI')
-    gui_parser.add_argument(
-        '-d',
-        '--database',
-        action='store',
-        help='Database file. Can be the local database name for SQLite, or an SQLAlchemy compatible URL such as postgresql+psycopg2://dirkjan@/roadtools',
-        default='roadrecon.db'
-    )
-    
+    gui_parser.add_argument('-d',
+                            '--database',
+                            action='store',
+                            help='Database file. Can be the local database name for SQLite, or an SQLAlchemy compatible URL such as postgresql+psycopg2://dirkjan@/roadtools',
+                            default='roadrecon.db')
     gui_parser.add_argument('--debug',
-        action='store_true',
-        help='Enable flask debug')
-    
+                            action='store_true',
+                            help='Enable flask debug')
     gui_parser.add_argument('--profile',
-        action='store_true',
-        help='Enable flask profiler')
-    
+                            action='store_true',
+                            help='Enable flask profiler')
     gui_parser.add_argument('--host',
-        type=str,
-        action='store',
-        help='HTTP Server host to bind to (default=127.0.0.1)',
-        default='127.0.0.1')
-    
+                            type=str,
+                            action='store',
+                            help='HTTP Server host to bind to (default=127.0.0.1)',
+                            default='127.0.0.1')
     gui_parser.add_argument('--port',
-        type=int,
-        action='store',
-        help='HTTP Server port (default=5000)',
-        default=5000
-    )
+                            type=int,
+                            action='store',
+                            help='HTTP Server port (default=5000)',
+                            default=5000)
 
     # Construct plugins module options
     plugin_parser = subparsers.add_parser('plugin', help='Run a ROADrecon plugin')
@@ -105,10 +98,10 @@ def main():
 
         # Every plugin uses at least the database, so add that option
         pparser.add_argument('-d',
-             '--database',
-             action='store',
-             help='Database file. Can be the local database name for SQLite, or an SQLAlchemy compatible URL such as postgresql+psycopg2://dirkjan@/roadtools',
-             default='roadrecon.db')
+                             '--database',
+                             action='store',
+                             help='Database file. Can be the local database name for SQLite, or an SQLAlchemy compatible URL such as postgresql+psycopg2://dirkjan@/roadtools',
+                             default='roadrecon.db')
         plugin_module.add_args(pparser)
 
 

--- a/roadrecon/roadtools/roadrecon/main.py
+++ b/roadrecon/roadtools/roadrecon/main.py
@@ -54,22 +54,34 @@ def main():
 
     # Construct GUI options
     gui_parser = subparsers.add_parser('gui', help='Launch the web-based GUI')
-    gui_parser.add_argument('-d',
-                            '--database',
-                            action='store',
-                            help='Database file. Can be the local database name for SQLite, or an SQLAlchemy compatible URL such as postgresql+psycopg2://dirkjan@/roadtools',
-                            default='roadrecon.db')
+    gui_parser.add_argument(
+        '-d',
+        '--database',
+        action='store',
+        help='Database file. Can be the local database name for SQLite, or an SQLAlchemy compatible URL such as postgresql+psycopg2://dirkjan@/roadtools',
+        default='roadrecon.db'
+    )
+    
     gui_parser.add_argument('--debug',
-                            action='store_true',
-                            help='Enable flask debug')
+        action='store_true',
+        help='Enable flask debug')
+    
     gui_parser.add_argument('--profile',
-                            action='store_true',
-                            help='Enable flask profiler')
+        action='store_true',
+        help='Enable flask profiler')
+    
+    gui_parser.add_argument('--host',
+        type=str,
+        action='store',
+        help='HTTP Server host to bind to (default=127.0.0.1)',
+        default='127.0.0.1')
+    
     gui_parser.add_argument('--port',
-                            type=int,
-                            action='store',
-                            help='HTTP Server port (default=5000)',
-                            default=5000)
+        type=int,
+        action='store',
+        help='HTTP Server port (default=5000)',
+        default=5000
+    )
 
     # Construct plugins module options
     plugin_parser = subparsers.add_parser('plugin', help='Run a ROADrecon plugin')
@@ -93,10 +105,10 @@ def main():
 
         # Every plugin uses at least the database, so add that option
         pparser.add_argument('-d',
-                             '--database',
-                             action='store',
-                             help='Database file. Can be the local database name for SQLite, or an SQLAlchemy compatible URL such as postgresql+psycopg2://dirkjan@/roadtools',
-                             default='roadrecon.db')
+             '--database',
+             action='store',
+             help='Database file. Can be the local database name for SQLite, or an SQLAlchemy compatible URL such as postgresql+psycopg2://dirkjan@/roadtools',
+             default='roadrecon.db')
         plugin_module.add_args(pparser)
 
 

--- a/roadrecon/roadtools/roadrecon/server.py
+++ b/roadrecon/roadtools/roadrecon/server.py
@@ -611,6 +611,11 @@ def main(args=None):
         parser.add_argument('--profile',
                             action='store_true',
                             help='Enable flask profiler')
+        parser.add_argument('--host',
+                    type=str,
+                    action='store',
+                    help='Host IP to bind to (default=127.0.0.1)',
+                    default='127.0.0.1')
         parser.add_argument('--port',
                             type=int,
                             action='store',
@@ -628,7 +633,8 @@ def main(args=None):
     if args.profile:
         from werkzeug.middleware.profiler import ProfilerMiddleware
         app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[5])
-    app.run(debug=args.debug, port=args.port)
+    
+    app.run(host=args.host, port=args.port, debug=args.debug)
 
 if __name__ == '__main__':
     main()

--- a/roadrecon/roadtools/roadrecon/server.py
+++ b/roadrecon/roadtools/roadrecon/server.py
@@ -599,47 +599,28 @@ def create_app_test():
 def main(args=None):
     global db
     if not args:
-        parser = argparse.ArgumentParser(
-            add_help=True,
-            description='ROADrecon GUI',
-            formatter_class=argparse.RawDescriptionHelpFormatter
-        )
-
-        parser.add_argument(
-            '-d',
-            '--database',
-            action='store',
-            help='Database file. Can be the local database name for SQLite, or an SQLAlchemy compatible URL such as postgresql+psycopg2://dirkjan@/roadtools',
-            default='roadrecon.db'
-        )
-
-        parser.add_argument(
-            '--debug',
-            action='store_true',
-            help='Enable flask debug'
-        )
-
-        parser.add_argument(
-            '--profile',
-            action='store_true',
-            help='Enable flask profiler'
-        )
-
-        parser.add_argument(
-            '--host',
-            type=str,
-            action='store',
-            help='Host IP to bind to (default=127.0.0.1)',
-            default='127.0.0.1'
-        )
-
-        parser.add_argument(
-            '--port',
-            type=int,
-            action='store',
-            help='HTTP Server port (default=5000)',
-            default=5000
-        )
+        parser = argparse.ArgumentParser(add_help=True, description='ROADrecon GUI', formatter_class=argparse.RawDescriptionHelpFormatter)
+        parser.add_argument('-d',
+                            '--database',
+                            action='store',
+                            help='Database file. Can be the local database name for SQLite, or an SQLAlchemy compatible URL such as postgresql+psycopg2://dirkjan@/roadtools',
+                            default='roadrecon.db')
+        parser.add_argument('--debug',
+                            action='store_true',
+                            help='Enable flask debug')
+        parser.add_argument('--profile',
+                            action='store_true',
+                            help='Enable flask profiler')
+        parser.add_argument('--host',
+                            type=str,
+                            action='store',
+                            help='Host IP to bind to (default=127.0.0.1)',
+                            default='127.0.0.1')
+        parser.add_argument('--port',
+                            type=int,
+                            action='store',
+                            help='HTTP Server port (default=5000)',
+                            default=5000)
         args = parser.parse_args()
     if not ':/' in args.database:
         if args.database[0] != '/':
@@ -652,7 +633,6 @@ def main(args=None):
     if args.profile:
         from werkzeug.middleware.profiler import ProfilerMiddleware
         app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[5])
-    
     app.run(host=args.host, port=args.port, debug=args.debug)
 
 if __name__ == '__main__':

--- a/roadrecon/roadtools/roadrecon/server.py
+++ b/roadrecon/roadtools/roadrecon/server.py
@@ -599,28 +599,47 @@ def create_app_test():
 def main(args=None):
     global db
     if not args:
-        parser = argparse.ArgumentParser(add_help=True, description='ROADrecon GUI', formatter_class=argparse.RawDescriptionHelpFormatter)
-        parser.add_argument('-d',
-                            '--database',
-                            action='store',
-                            help='Database file. Can be the local database name for SQLite, or an SQLAlchemy compatible URL such as postgresql+psycopg2://dirkjan@/roadtools',
-                            default='roadrecon.db')
-        parser.add_argument('--debug',
-                            action='store_true',
-                            help='Enable flask debug')
-        parser.add_argument('--profile',
-                            action='store_true',
-                            help='Enable flask profiler')
-        parser.add_argument('--host',
-                    type=str,
-                    action='store',
-                    help='Host IP to bind to (default=127.0.0.1)',
-                    default='127.0.0.1')
-        parser.add_argument('--port',
-                            type=int,
-                            action='store',
-                            help='HTTP Server port (default=5000)',
-                            default=5000)
+        parser = argparse.ArgumentParser(
+            add_help=True,
+            description='ROADrecon GUI',
+            formatter_class=argparse.RawDescriptionHelpFormatter
+        )
+
+        parser.add_argument(
+            '-d',
+            '--database',
+            action='store',
+            help='Database file. Can be the local database name for SQLite, or an SQLAlchemy compatible URL such as postgresql+psycopg2://dirkjan@/roadtools',
+            default='roadrecon.db'
+        )
+
+        parser.add_argument(
+            '--debug',
+            action='store_true',
+            help='Enable flask debug'
+        )
+
+        parser.add_argument(
+            '--profile',
+            action='store_true',
+            help='Enable flask profiler'
+        )
+
+        parser.add_argument(
+            '--host',
+            type=str,
+            action='store',
+            help='Host IP to bind to (default=127.0.0.1)',
+            default='127.0.0.1'
+        )
+
+        parser.add_argument(
+            '--port',
+            type=int,
+            action='store',
+            help='HTTP Server port (default=5000)',
+            default=5000
+        )
         args = parser.parse_args()
     if not ':/' in args.database:
         if args.database[0] != '/':


### PR DESCRIPTION
Hi,

This is a small pull request to add a `--host` argument to the `roadrecon gui` command.  
It allows users to specify which interface to bind the Flask app to. Which is useful when serving the GUI on a private or remote network (e.g. `--host 0.0.0.0`).

This change improves usability in containerized or multi-host environments, and keeps `127.0.0.1` as the default for backwards compatibility.

Thanks!
