### PR TITLE
Add support for Graph Explorer

### DIFF
--- a/roadlib/roadtools/roadlib/auth.py
+++ b/roadlib/roadtools/roadlib/auth.py
@@ -23,15 +23,27 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.serialization import pkcs12
 from cryptography import x509
-from roadtools.roadlib.constants import WELLKNOWN_RESOURCES, WELLKNOWN_CLIENTS, WELLKNOWN_USER_AGENTS, \
-    DSSO_BODY_KERBEROS, DSSO_BODY_USERPASS, SAML_TOKEN_TYPE_V1, SAML_TOKEN_TYPE_V2, GRANT_TYPE_SAML1_1, \
-    WSS_SAML_TOKEN_PROFILE_V1_1, WSS_SAML_TOKEN_PROFILE_V2, GRANT_TYPE_SAML2
+from roadtools.roadlib.constants import (
+    WELLKNOWN_RESOURCES,
+    WELLKNOWN_CLIENTS,
+    WELLKNOWN_USER_AGENTS,
+    DSSO_BODY_KERBEROS,
+    DSSO_BODY_USERPASS,
+    SAML_TOKEN_TYPE_V1,
+    SAML_TOKEN_TYPE_V2,
+    GRANT_TYPE_SAML1_1,
+    WSS_SAML_TOKEN_PROFILE_V1_1,
+    WSS_SAML_TOKEN_PROFILE_V2,
+    GRANT_TYPE_SAML2,
+)
 from roadtools.roadlib.wstrust import Mex, build_rst, parse_wstrust_response
 import requests
 import jwt
 
+
 def get_data(data):
-    return base64.urlsafe_b64decode(data+('='*(len(data)%4)))
+    return base64.urlsafe_b64decode(data + ("=" * (len(data) % 4)))
+
 
 class AuthenticationException(Exception):
     """
@@ -39,18 +51,26 @@ class AuthenticationException(Exception):
     goes back to the user.
     """
 
-class Authentication():
+
+class Authentication:
     """
     Authentication class for ROADtools
     """
-    def __init__(self, username=None, password=None, tenant=None, client_id='1b730954-1685-4b74-9bfd-dac224a7b894'):
+
+    def __init__(
+        self,
+        username=None,
+        password=None,
+        tenant=None,
+        client_id="1b730954-1685-4b74-9bfd-dac224a7b894",
+    ):
         self.username = username
         self.password = password
         self.tenant = tenant
         self.client_id = None
         self.origin = None
         self.set_client_id(client_id)
-        self.resource_uri = 'https://graph.windows.net/'
+        self.resource_uri = "https://graph.windows.net/"
         self.tokendata = {}
         self.refresh_token = None
         self.saml_token = None
@@ -71,19 +91,22 @@ class Authentication():
         self.appcertificate = None
         self.appkeydata = None
 
-    def get_authority_url(self, default_tenant='common'):
+    def get_authority_url(self, default_tenant="common"):
         """
         Returns the authority URL for the tenant specified, or the
         common one if no tenant was specified
         """
         if self.tenant is not None:
-            return f'https://login.microsoftonline.com/{self.tenant}'
-        return f'https://login.microsoftonline.com/{default_tenant}'
+            return f"https://login.microsoftonline.com/{self.tenant}"
+        return f"https://login.microsoftonline.com/{default_tenant}"
 
-    def set_client_id(self, clid):
+    def set_client_id(self, clid: str = None):
         """
         Sets client ID to use (accepts aliases)
         """
+        if clid is None:
+            return
+
         self.client_id = self.lookup_client_id(clid)
 
     def set_scope(self, scope):
@@ -92,6 +115,7 @@ class Authentication():
         """
         if not scope:
             return
+
         self.scope = self.lookup_scope_resource(scope)
 
     def set_origin_value(self, origin, redirect_uri=None):
@@ -99,8 +123,9 @@ class Authentication():
         Sets Origin header to use
         If the value "ru" is used, we take it from the redirect URL
         """
-        if origin is not None and origin.lower() == 'ru' and redirect_uri is not None:
+        if origin is not None and origin.lower() == "ru" and redirect_uri is not None:
             origin = redirect_uri
+
         self.origin = origin
 
     def set_resource_uri(self, uri):
@@ -120,7 +145,7 @@ class Authentication():
         Discover whether this is a federated user
         """
         # Tenant specific endpoint seems to not work for this?
-        authority_uri = 'https://login.microsoftonline.com/common'
+        authority_uri = "https://login.microsoftonline.com/common"
         user = quote_plus(username)
         res = self.requests_get(f"{authority_uri}/UserRealm/{user}?api-version=1.0")
         response = res.json()
@@ -131,7 +156,7 @@ class Authentication():
         Discover whether this is a federated user
         """
         # Tenant specific endpoint seems to not work for this?
-        authority_uri = 'https://login.microsoftonline.com/common'
+        authority_uri = "https://login.microsoftonline.com/common"
         user = quote_plus(username)
         res = self.requests_get(f"{authority_uri}/UserRealm/{user}?api-version=2.0")
         response = res.json()
@@ -153,58 +178,60 @@ class Authentication():
             self.claims[token] = {}
         self.claims[token][claim] = {}
         if value:
-            self.claims[token][claim]['value'] = value
+            self.claims[token][claim]["value"] = value
         elif values:
-            self.claims[token][claim]['values'] = values
+            self.claims[token][claim]["values"] = values
         if essential:
-            self.claims[token][claim]['essential'] = essential
+            self.claims[token][claim]["essential"] = essential
 
     def set_cae(self):
         """
         Request a Continuous Access Evaluation token
         """
-        self.add_claim('access_token', 'xms_cc', values=['CP1'])
+        self.add_claim("access_token", "xms_cc", values=["CP1"])
 
     def set_force_mfa(self):
         """
         Force MFA during auth
         """
-        self.add_claim('access_token', 'amr', values=['mfa'])
+        self.add_claim("access_token", "amr", values=["mfa"])
 
     def set_force_ngcmfa(self):
         """
         Force NGC MFA during auth
         """
-        self.add_claim('access_token', 'amr', values=['ngcmfa','mfa'])
+        self.add_claim("access_token", "amr", values=["ngcmfa", "mfa"])
 
     def has_force_mfa(self):
         """
         Check whether MFA enforcement is set
         """
         try:
-            values = self.claims['access_token']['amr']['values']
+            values = self.claims["access_token"]["amr"]["values"]
         except (KeyError, ValueError, TypeError):
             return False
-        return 'mfa' in values or 'ngcmfa' in values
+        return "mfa" in values or "ngcmfa" in values
 
     def gen_pkce_secret(self):
         """
         Generate a secret for PKCE
         """
         alphabet = string.ascii_letters + string.digits
-        self.pkce_secret = ''.join(secrets.choice(alphabet) for i in range(43))
+        self.pkce_secret = "".join(secrets.choice(alphabet) for i in range(43))
 
     def get_pkce_challenge(self):
         """
         Get PKCE challenge (sha256 hash) of the generated secret
         """
         digest = hashes.Hash(hashes.SHA256())
-        digest.update(self.pkce_secret.encode('utf-8'))
+        digest.update(self.pkce_secret.encode("utf-8"))
         hashoutput = digest.finalize()
-        challenge = base64.urlsafe_b64encode(hashoutput).decode('utf-8').rstrip('=')
+        challenge = base64.urlsafe_b64encode(hashoutput).decode("utf-8").rstrip("=")
         return challenge
 
-    def loadappcert(self, pemfile=None, privkeyfile=None, pfxfile=None, pfxpass=None, pfxbase64=None):
+    def loadappcert(
+        self, pemfile=None, privkeyfile=None, pfxfile=None, pfxpass=None, pfxbase64=None
+    ):
         """
         Load a certificate from disk for usage with application auth
         """
@@ -213,22 +240,28 @@ class Authentication():
                 self.appcertificate = x509.load_pem_x509_certificate(certf.read())
             with open(privkeyfile, "rb") as keyf:
                 self.appkeydata = keyf.read()
-                self.appprivkey = serialization.load_pem_private_key(self.appkeydata, password=None)
+                self.appprivkey = serialization.load_pem_private_key(
+                    self.appkeydata, password=None
+                )
             return True
         if privkeyfile:
             with open(privkeyfile, "rb") as keyf:
                 self.appkeydata = keyf.read()
-                self.appprivkey = serialization.load_pem_private_key(self.appkeydata, password=None)
+                self.appprivkey = serialization.load_pem_private_key(
+                    self.appkeydata, password=None
+                )
             return True
         if pfxfile or pfxbase64:
             if pfxfile:
-                with open(pfxfile, 'rb') as pfxf:
+                with open(pfxfile, "rb") as pfxf:
                     pfxdata = pfxf.read()
             if pfxbase64:
                 pfxdata = base64.b64decode(pfxbase64)
             if isinstance(pfxpass, str):
                 pfxpass = pfxpass.encode()
-            self.appprivkey, self.appcertificate, _ = pkcs12.load_key_and_certificates(pfxdata, pfxpass)
+            self.appprivkey, self.appcertificate, _ = pkcs12.load_key_and_certificates(
+                pfxdata, pfxpass
+            )
             # PyJWT needs the key as PEM data anyway, so encode it
             self.appkeydata = self.appprivkey.private_bytes(
                 encoding=serialization.Encoding.PEM,
@@ -236,7 +269,9 @@ class Authentication():
                 encryption_algorithm=serialization.NoEncryption(),
             )
             return True
-        print('You must specify either a PEM certificate file and private key file or a pfx file with the device keypair.')
+        print(
+            "You must specify either a PEM certificate file and private key file or a pfx file with the device keypair."
+        )
         return False
 
     def authenticate_device_code(self):
@@ -257,24 +292,24 @@ class Authentication():
             "resource": self.resource_uri,
         }
         if self.scope:
-            data['scope'] = self.scope
+            data["scope"] = self.scope
         if additionaldata:
             data = {**data, **additionaldata}
         if self.has_force_mfa():
-            data['amr_values'] = 'ngcmfa'
+            data["amr_values"] = "ngcmfa"
         res = self.requests_post(f"{authority_uri}/oauth2/devicecode", data=data)
         if res.status_code != 200:
             raise AuthenticationException(res.text)
         responsedata = res.json()
-        print(responsedata['message'])
+        print(responsedata["message"])
         # print(f"Code expires in {responsedata['expires_in']} seconds")
-        interval = float(responsedata['interval'])
-        device_code = responsedata['device_code']
+        interval = float(responsedata["interval"])
+        device_code = responsedata["device_code"]
 
         polldata = {
             "client_id": self.client_id,
             "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
-            "code": device_code
+            "code": device_code,
         }
         while True:
             time.sleep(interval)
@@ -282,11 +317,11 @@ class Authentication():
             tokenreply = res.json()
             if res.status_code != 200:
                 # Keep polling
-                if tokenreply['error'] == 'authorization_pending':
+                if tokenreply["error"] == "authorization_pending":
                     continue
-                if tokenreply['error'] in ('expired_token', 'code_expired'):
+                if tokenreply["error"] in ("expired_token", "code_expired"):
                     raise AuthenticationException("The code has expired.")
-                if tokenreply['error'] == 'authorization_declined':
+                if tokenreply["error"] == "authorization_declined":
                     raise AuthenticationException("The user declined the sign-in.")
                 # If not handled, raise
                 raise AuthenticationException(res.text)
@@ -297,7 +332,9 @@ class Authentication():
         self.tokendata = self.tokenreply_to_tokendata(tokenreply)
         return self.tokendata
 
-    def authenticate_device_code_native_v2(self, additionaldata=None, returnreply=False):
+    def authenticate_device_code_native_v2(
+        self, additionaldata=None, returnreply=False
+    ):
         """
         Authenticate with device code flow
         Native version without adal
@@ -312,32 +349,34 @@ class Authentication():
         if self.use_cae:
             self.set_cae()
         if self.claims:
-            data['claims'] = json.dumps(self.claims)
+            data["claims"] = json.dumps(self.claims)
         res = self.requests_post(f"{authority_uri}/oauth2/v2.0/devicecode", data=data)
         if res.status_code != 200:
             raise AuthenticationException(res.text)
         responsedata = res.json()
-        print(responsedata['message'])
+        print(responsedata["message"])
         # print(f"Code expires in {responsedata['expires_in']} seconds")
-        interval = float(responsedata['interval'])
-        device_code = responsedata['device_code']
+        interval = float(responsedata["interval"])
+        device_code = responsedata["device_code"]
 
         polldata = {
             "client_id": self.client_id,
             "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
-            "code": device_code
+            "code": device_code,
         }
         while True:
             time.sleep(interval)
-            res = self.requests_post(f"{authority_uri}/oauth2/v2.0/token", data=polldata)
+            res = self.requests_post(
+                f"{authority_uri}/oauth2/v2.0/token", data=polldata
+            )
             tokenreply = res.json()
             if res.status_code != 200:
                 # Keep polling
-                if tokenreply['error'] == 'authorization_pending':
+                if tokenreply["error"] == "authorization_pending":
                     continue
-                if tokenreply['error'] in ('expired_token', 'code_expired'):
+                if tokenreply["error"] in ("expired_token", "code_expired"):
                     raise AuthenticationException("The code has expired.")
-                if tokenreply['error'] == 'authorization_declined':
+                if tokenreply["error"] == "authorization_declined":
                     raise AuthenticationException("The user declined the sign-in.")
                 # If not handled, raise
                 raise AuthenticationException(res.text)
@@ -371,22 +410,37 @@ class Authentication():
         """
         Fetch saml token from usernamemixed endpoint on the federation server
         """
-        wstrust_endpoint = self.find_federation_endpoint(federationdata['federation_metadata_url'])
-        cloud_audience_urn = wstrust_endpoint.get("cloud_audience_urn", "urn:federation:MicrosoftOnline")
-        endpoint_address =  wstrust_endpoint.get("address", federationdata.get("federation_active_auth_url"))
+        wstrust_endpoint = self.find_federation_endpoint(
+            federationdata["federation_metadata_url"]
+        )
+        cloud_audience_urn = wstrust_endpoint.get(
+            "cloud_audience_urn", "urn:federation:MicrosoftOnline"
+        )
+        endpoint_address = wstrust_endpoint.get(
+            "address", federationdata.get("federation_active_auth_url")
+        )
         soap_action = wstrust_endpoint.get("action")
         if soap_action is None:
-            if '/trust/2005/usernamemixed' in endpoint_address:
+            if "/trust/2005/usernamemixed" in endpoint_address:
                 soap_action = Mex.ACTION_2005
-            elif '/trust/13/usernamemixed' in endpoint_address:
+            elif "/trust/13/usernamemixed" in endpoint_address:
                 soap_action = Mex.ACTION_13
         if soap_action not in (Mex.ACTION_13, Mex.ACTION_2005):
-            raise ValueError("Unsupported soap action: %s. "
-                "Contact your administrator to check your ADFS's MEX settings." % soap_action)
-        data = build_rst( self.username, self.password, cloud_audience_urn, endpoint_address, soap_action)
+            raise ValueError(
+                "Unsupported soap action: %s. "
+                "Contact your administrator to check your ADFS's MEX settings."
+                % soap_action
+            )
+        data = build_rst(
+            self.username,
+            self.password,
+            cloud_audience_urn,
+            endpoint_address,
+            soap_action,
+        )
         headers = {
-            'Content-type':'application/soap+xml; charset=utf-8',
-            'SOAPAction': soap_action,
+            "Content-type": "application/soap+xml; charset=utf-8",
+            "SOAPAction": soap_action,
         }
         resp = self.requests_post(endpoint_address, data=data, headers=headers)
         if resp.status_code >= 400:
@@ -395,31 +449,51 @@ class Authentication():
         # so we ignore the 5xx error and parse the XML instead
         wstrust_result = parse_wstrust_response(resp.text)
         if not ("token" in wstrust_result and "type" in wstrust_result):
-            raise AuthenticationException("Unsuccessful authentication against the federation server. %s" % wstrust_result)
+            raise AuthenticationException(
+                "Unsuccessful authentication against the federation server. %s"
+                % wstrust_result
+            )
 
         grant_type = {
             SAML_TOKEN_TYPE_V1: GRANT_TYPE_SAML1_1,
             SAML_TOKEN_TYPE_V2: GRANT_TYPE_SAML2,
             WSS_SAML_TOKEN_PROFILE_V1_1: GRANT_TYPE_SAML1_1,
-            WSS_SAML_TOKEN_PROFILE_V2: GRANT_TYPE_SAML2
-            }.get(wstrust_result.get("type"))
+            WSS_SAML_TOKEN_PROFILE_V2: GRANT_TYPE_SAML2,
+        }.get(wstrust_result.get("type"))
         if not grant_type:
             raise AuthenticationException(
-                "RSTR returned unknown token type: %s", wstrust_result.get("type"))
+                "RSTR returned unknown token type: %s", wstrust_result.get("type")
+            )
         return wstrust_result, grant_type
 
-    def authenticate_username_password_federation_native(self, federationdata, additionaldata=None, returnreply=False):
+    def authenticate_username_password_federation_native(
+        self, federationdata, additionaldata=None, returnreply=False
+    ):
         """
         Authenticate using user w/ username + password in federated environments
         This doesn't work for users or tenants that have multi-factor authentication required.
         Native version without adal
         """
-        wstrust_result, grant_type = self.get_saml_token_with_username_password(federationdata)
+        wstrust_result, grant_type = self.get_saml_token_with_username_password(
+            federationdata
+        )
         if self.scope:
-            return self.authenticate_with_saml_native_v2(wstrust_result['token'], grant_type=grant_type, additionaldata=additionaldata, returnreply=returnreply)
-        return self.authenticate_with_saml_native(wstrust_result['token'], grant_type=grant_type, additionaldata=additionaldata, returnreply=returnreply)
+            return self.authenticate_with_saml_native_v2(
+                wstrust_result["token"],
+                grant_type=grant_type,
+                additionaldata=additionaldata,
+                returnreply=returnreply,
+            )
+        return self.authenticate_with_saml_native(
+            wstrust_result["token"],
+            grant_type=grant_type,
+            additionaldata=additionaldata,
+            returnreply=returnreply,
+        )
 
-    def authenticate_username_password_native(self, client_secret=None, additionaldata=None, returnreply=False):
+    def authenticate_username_password_native(
+        self, client_secret=None, additionaldata=None, returnreply=False
+    ):
         """
         Authenticate using user w/ username + password.
         This doesn't work for users or tenants that have multi-factor authentication required.
@@ -431,12 +505,12 @@ class Authentication():
             "grant_type": "password",
             "resource": self.resource_uri,
             "username": self.username,
-            "password": self.password
+            "password": self.password,
         }
         if self.scope:
-            data['scope'] = self.scope
+            data["scope"] = self.scope
         if client_secret:
-            data['client_secret'] = client_secret
+            data["client_secret"] = client_secret
         if additionaldata:
             data = {**data, **additionaldata}
         res = self.requests_post(f"{authority_uri}/oauth2/token", data=data)
@@ -448,28 +522,30 @@ class Authentication():
         self.tokendata = self.tokenreply_to_tokendata(tokenreply)
         return self.tokendata
 
-    def authenticate_username_password_native_v2(self, client_secret=None, additionaldata=None, returnreply=False):
+    def authenticate_username_password_native_v2(
+        self, client_secret=None, additionaldata=None, returnreply=False
+    ):
         """
         Authenticate using user w/ username + password.
         This doesn't work for users or tenants that have multi-factor authentication required.
         Native version without adal, for identity platform v2 endpoint
         """
-        authority_uri = self.get_authority_url('organizations')
+        authority_uri = self.get_authority_url("organizations")
         data = {
             "client_id": self.client_id,
             "grant_type": "password",
             "scope": self.scope,
             "username": self.username,
-            "password": self.password
+            "password": self.password,
         }
         if client_secret:
-            data['client_secret'] = client_secret
+            data["client_secret"] = client_secret
         if additionaldata:
             data = {**data, **additionaldata}
         if self.use_cae:
             self.set_cae()
         if self.claims:
-            data['claims'] = json.dumps(self.claims)
+            data["claims"] = json.dumps(self.claims)
         res = self.requests_post(f"{authority_uri}/oauth2/v2.0/token", data=data)
         if res.status_code != 200:
             raise AuthenticationException(res.text)
@@ -485,7 +561,9 @@ class Authentication():
         """
         return self.authenticate_as_app_native()
 
-    def authenticate_as_app_native(self, client_secret=None, assertion=None, additionaldata=None, returnreply=False):
+    def authenticate_as_app_native(
+        self, client_secret=None, assertion=None, additionaldata=None, returnreply=False
+    ):
         """
         Authenticate with a client id + secret or assertion
         Essentially an implementation of the oauth2 client credentials grant on the v1 auth endpoint
@@ -497,13 +575,15 @@ class Authentication():
             "resource": self.resource_uri,
         }
         if assertion:
-            data['client_assertion_type'] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
-            data['client_assertion'] = assertion
+            data["client_assertion_type"] = (
+                "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+            )
+            data["client_assertion"] = assertion
         else:
             if client_secret:
-                data['client_secret'] = client_secret
+                data["client_secret"] = client_secret
             else:
-                data['client_secret'] = self.password
+                data["client_secret"] = self.password
         if additionaldata:
             data = {**data, **additionaldata}
         res = self.requests_post(f"{authority_uri}/oauth2/token", data=data)
@@ -515,7 +595,9 @@ class Authentication():
         self.tokendata = self.tokenreply_to_tokendata(tokenreply)
         return self.tokendata
 
-    def authenticate_as_app_native_v2(self, client_secret=None, assertion=None, additionaldata=None, returnreply=False):
+    def authenticate_as_app_native_v2(
+        self, client_secret=None, assertion=None, additionaldata=None, returnreply=False
+    ):
         """
         Authenticate with a client id + secret or assertion
         Essentially an implementation of the oauth2 client credentials grant on the v2 auth endpoint
@@ -527,19 +609,21 @@ class Authentication():
             "scope": self.scope,
         }
         if assertion:
-            data['client_assertion_type'] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
-            data['client_assertion'] = assertion
+            data["client_assertion_type"] = (
+                "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+            )
+            data["client_assertion"] = assertion
         else:
             if client_secret:
-                data['client_secret'] = client_secret
+                data["client_secret"] = client_secret
             else:
-                data['client_secret'] = self.password
+                data["client_secret"] = self.password
         if additionaldata:
             data = {**data, **additionaldata}
         if self.use_cae:
             self.set_cae()
         if self.claims:
-            data['claims'] = json.dumps(self.claims)
+            data["claims"] = json.dumps(self.claims)
         res = self.requests_post(f"{authority_uri}/oauth2/v2.0/token", data=data)
         if res.status_code != 200:
             raise AuthenticationException(res.text)
@@ -549,7 +633,14 @@ class Authentication():
         self.tokendata = self.tokenreply_to_tokendata(tokenreply)
         return self.tokendata
 
-    def authenticate_on_behalf_of_native(self, token, client_secret=None, assertion=None, additionaldata=None, returnreply=False):
+    def authenticate_on_behalf_of_native(
+        self,
+        token,
+        client_secret=None,
+        assertion=None,
+        additionaldata=None,
+        returnreply=False,
+    ):
         """
         Authenticate on-behalf-of a user, providing their token
         plus a middle tier app client id + secret (client secret or certificate based assertion)
@@ -560,16 +651,18 @@ class Authentication():
             "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
             "resource": self.resource_uri,
             "assertion": token,
-            "requested_token_use": "on_behalf_of"
+            "requested_token_use": "on_behalf_of",
         }
         if assertion:
-            data['client_assertion_type'] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
-            data['client_assertion'] = assertion
+            data["client_assertion_type"] = (
+                "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+            )
+            data["client_assertion"] = assertion
         else:
             if client_secret:
-                data['client_secret'] = client_secret
+                data["client_secret"] = client_secret
             else:
-                data['client_secret'] = self.password
+                data["client_secret"] = self.password
         if additionaldata:
             data = {**data, **additionaldata}
         res = self.requests_post(f"{authority_uri}/oauth2/token", data=data)
@@ -581,7 +674,14 @@ class Authentication():
         self.tokendata = self.tokenreply_to_tokendata(tokenreply)
         return self.tokendata
 
-    def authenticate_on_behalf_of_native_v2(self, token, client_secret=None, assertion=None, additionaldata=None, returnreply=False):
+    def authenticate_on_behalf_of_native_v2(
+        self,
+        token,
+        client_secret=None,
+        assertion=None,
+        additionaldata=None,
+        returnreply=False,
+    ):
         """
         Authenticate on-behalf-of a user, providing their token
         plus a middle tier app client id + secret (client secret or certificate based assertion)
@@ -593,22 +693,24 @@ class Authentication():
             "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
             "scope": self.scope,
             "assertion": token,
-            "requested_token_use": "on_behalf_of"
+            "requested_token_use": "on_behalf_of",
         }
         if assertion:
-            data['client_assertion_type'] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
-            data['client_assertion'] = assertion
+            data["client_assertion_type"] = (
+                "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+            )
+            data["client_assertion"] = assertion
         else:
             if client_secret:
-                data['client_secret'] = client_secret
+                data["client_secret"] = client_secret
             else:
-                data['client_secret'] = self.password
+                data["client_secret"] = self.password
         if additionaldata:
             data = {**data, **additionaldata}
         if self.use_cae:
             self.set_cae()
         if self.claims:
-            data['claims'] = json.dumps(self.claims)
+            data["claims"] = json.dumps(self.claims)
         res = self.requests_post(f"{authority_uri}/oauth2/v2.0/token", data=data)
         if res.status_code != 200:
             raise AuthenticationException(res.text)
@@ -619,31 +721,33 @@ class Authentication():
         return self.tokendata
 
     def generate_app_assertion(self, use_v2=True):
-        data = self.appcertificate.public_bytes(
-            serialization.Encoding.DER
-        )
+        data = self.appcertificate.public_bytes(serialization.Encoding.DER)
         digest = hashes.Hash(hashes.SHA1())
         digest.update(data)
         thumbprint = digest.finalize()
         headers = {
-            "x5t": base64.urlsafe_b64encode(thumbprint).decode('utf-8'),
+            "x5t": base64.urlsafe_b64encode(thumbprint).decode("utf-8"),
         }
         if use_v2:
-            suffix = '/oauth2/v2.0/token'
+            suffix = "/oauth2/v2.0/token"
         else:
-            suffix = '/oauth2/token'
+            suffix = "/oauth2/token"
         payload = {
             "aud": self.get_authority_url() + suffix,
             "iat": str(int(time.time())),
             "nbf": str(int(time.time())),
-            "exp": str(int(time.time())+(300)),
+            "exp": str(int(time.time()) + (300)),
             "iss": self.client_id,
             "jti": str(uuid.uuid4()),
-            "sub": self.client_id
+            "sub": self.client_id,
         }
-        return jwt.encode(payload, algorithm='RS256', key=self.appkeydata, headers=headers)
+        return jwt.encode(
+            payload, algorithm="RS256", key=self.appkeydata, headers=headers
+        )
 
-    def generate_federated_assertion(self, iss, sub, kid=None, aud='api://AzureADTokenExchange'):
+    def generate_federated_assertion(
+        self, iss, sub, kid=None, aud="api://AzureADTokenExchange"
+    ):
         """
         Generate a federated assertion for the specified key ID, issuer, subject and audience.
         Appkeypem should be a PEM encoded private key (as bytes), if not specified it should already be loaded
@@ -651,35 +755,37 @@ class Authentication():
         if not kid:
             # Calculate as thumbprint of cert
             if not self.appcertificate:
-                raise ValueError('Either an app certificate should be specified or a manual key ID (kid) should be provided')
-            data = self.appcertificate.public_bytes(
-                serialization.Encoding.DER
-            )
+                raise ValueError(
+                    "Either an app certificate should be specified or a manual key ID (kid) should be provided"
+                )
+            data = self.appcertificate.public_bytes(serialization.Encoding.DER)
             digest = hashes.Hash(hashes.SHA1())
             digest.update(data)
-            kid = base64.urlsafe_b64encode(digest.finalize()).decode('utf-8')
-        headers = {
-            'kid':kid
-        }
+            kid = base64.urlsafe_b64encode(digest.finalize()).decode("utf-8")
+        headers = {"kid": kid}
         payload = {
             "aud": aud,
             "iat": str(int(time.time())),
             "nbf": str(int(time.time())),
-            "exp": str(int(time.time())+(300)),
+            "exp": str(int(time.time()) + (300)),
             "iss": iss,
             "jti": str(uuid.uuid4()),
-            "sub": sub
+            "sub": sub,
         }
-        return jwt.encode(payload, algorithm='RS256', key=self.appkeydata, headers=headers)
+        return jwt.encode(
+            payload, algorithm="RS256", key=self.appkeydata, headers=headers
+        )
 
     def authenticate_with_refresh(self, oldtokendata):
         """
         Authenticate with a refresh token, refreshes the refresh token
         and obtains an access token
         """
-        return self.authenticate_with_refresh_native(oldtokendata['refreshToken'])
+        return self.authenticate_with_refresh_native(oldtokendata["refreshToken"])
 
-    def authenticate_with_refresh_native(self, refresh_token, client_secret=None, additionaldata=None, returnreply=False):
+    def authenticate_with_refresh_native(
+        self, refresh_token, client_secret=None, additionaldata=None, returnreply=False
+    ):
         """
         Authenticate with a refresh token plus optional secret in case of a non-public app (authorization grant)
         Native ROADlib implementation without adal requirement
@@ -692,7 +798,7 @@ class Authentication():
             "resource": self.resource_uri,
         }
         if client_secret:
-            data['client_secret'] = client_secret
+            data["client_secret"] = client_secret
         if additionaldata:
             data = {**data, **additionaldata}
         res = self.requests_post(f"{authority_uri}/oauth2/token", data=data)
@@ -703,10 +809,12 @@ class Authentication():
             return tokenreply
         self.tokendata = self.tokenreply_to_tokendata(tokenreply)
         if self.origin:
-            self.tokendata['originheader'] = self.origin
+            self.tokendata["originheader"] = self.origin
         return self.tokendata
 
-    def authenticate_with_refresh_native_v2(self, refresh_token, client_secret=None, additionaldata=None, returnreply=False):
+    def authenticate_with_refresh_native_v2(
+        self, refresh_token, client_secret=None, additionaldata=None, returnreply=False
+    ):
         """
         Authenticate with a refresh token plus optional secret in case of a non-public app (authorization grant)
         Native ROADlib implementation without adal requirement
@@ -720,11 +828,11 @@ class Authentication():
             "scope": self.scope,
         }
         if client_secret:
-            data['client_secret'] = client_secret
+            data["client_secret"] = client_secret
         if self.use_cae:
             self.set_cae()
         if self.claims:
-            data['claims'] = json.dumps(self.claims)
+            data["claims"] = json.dumps(self.claims)
         if additionaldata:
             data = {**data, **additionaldata}
         res = self.requests_post(f"{authority_uri}/oauth2/v2.0/token", data=data)
@@ -735,7 +843,7 @@ class Authentication():
             return tokenreply
         self.tokendata = self.tokenreply_to_tokendata(tokenreply)
         if self.origin:
-            self.tokendata['originheader'] = self.origin
+            self.tokendata["originheader"] = self.origin
         return self.tokendata
 
     def authenticate_with_code(self, code, redirurl, client_secret=None):
@@ -745,7 +853,15 @@ class Authentication():
         """
         return self.authenticate_with_code_native(code, redirurl, client_secret)
 
-    def authenticate_with_code_native(self, code, redirurl, client_secret=None, pkce_secret=None, additionaldata=None, returnreply=False):
+    def authenticate_with_code_native(
+        self,
+        code,
+        redirurl,
+        client_secret=None,
+        pkce_secret=None,
+        additionaldata=None,
+        returnreply=False,
+    ):
         """
         Authenticate with a code plus optional secret in case of a non-public app (authorization grant)
         Native ROADlib implementation without adal requirement - also supports PKCE
@@ -759,13 +875,13 @@ class Authentication():
             "resource": self.resource_uri,
         }
         if client_secret:
-            data['client_secret'] = client_secret
+            data["client_secret"] = client_secret
         if additionaldata:
             data = {**data, **additionaldata}
         if not pkce_secret and self.use_pkce:
             pkce_secret = self.pkce_secret
         if pkce_secret:
-            data['code_verifier'] = pkce_secret
+            data["code_verifier"] = pkce_secret
         res = self.requests_post(f"{authority_uri}/oauth2/token", data=data)
         if res.status_code != 200:
             raise AuthenticationException(res.text)
@@ -775,7 +891,15 @@ class Authentication():
         self.tokendata = self.tokenreply_to_tokendata(tokenreply)
         return self.tokendata
 
-    def authenticate_with_code_native_v2(self, code, redirurl, client_secret=None, pkce_secret=None, additionaldata=None, returnreply=False):
+    def authenticate_with_code_native_v2(
+        self,
+        code,
+        redirurl,
+        client_secret=None,
+        pkce_secret=None,
+        additionaldata=None,
+        returnreply=False,
+    ):
         """
         Authenticate with a code plus optional secret in case of a non-public app (authorization grant)
         Native ROADlib implementation without adal requirement - also supports PKCE
@@ -790,17 +914,17 @@ class Authentication():
             "scope": self.scope,
         }
         if client_secret:
-            data['client_secret'] = client_secret
+            data["client_secret"] = client_secret
         if additionaldata:
             data = {**data, **additionaldata}
         if self.use_cae:
             self.set_cae()
         if self.claims:
-            data['claims'] = json.dumps(self.claims)
+            data["claims"] = json.dumps(self.claims)
         if not pkce_secret and self.use_pkce:
             pkce_secret = self.pkce_secret
         if pkce_secret:
-            data['code_verifier'] = pkce_secret
+            data["code_verifier"] = pkce_secret
         res = self.requests_post(f"{authority_uri}/oauth2/v2.0/token", data=data)
         if res.status_code != 200:
             raise AuthenticationException(res.text)
@@ -811,18 +935,18 @@ class Authentication():
         return self.tokendata
 
     def authenticate_with_code_encrypted(self, code, sessionkey, redirurl):
-        '''
+        """
         Encrypted code redemption. Like normal code flow but requires
         session key to decrypt response.
-        '''
+        """
         authority_uri = self.get_authority_url()
         data = {
             "grant_type": "authorization_code",
             "code": code,
             "redirect_uri": redirurl,
             "client_id": self.client_id,
-            "client_info":1,
-            "windows_api_version":"2.0"
+            "client_info": 1,
+            "windows_api_version": "2.0",
         }
         res = self.requests_post(f"{authority_uri}/oauth2/token", data=data)
         if res.status_code != 200:
@@ -831,7 +955,13 @@ class Authentication():
         data = self.decrypt_auth_response(prtdata, sessionkey, asjson=True)
         return data
 
-    def authenticate_with_saml_native(self, saml_token, additionaldata=None, returnreply=False, grant_type=GRANT_TYPE_SAML1_1):
+    def authenticate_with_saml_native(
+        self,
+        saml_token,
+        additionaldata=None,
+        returnreply=False,
+        grant_type=GRANT_TYPE_SAML1_1,
+    ):
         """
         Authenticate with a SAML token from the Federation Server
         Native ROADlib implementation without adal requirement
@@ -840,7 +970,7 @@ class Authentication():
         data = {
             "client_id": self.client_id,
             "grant_type": grant_type,
-            "assertion": base64.b64encode(saml_token.encode('utf-8')).decode('utf-8'),
+            "assertion": base64.b64encode(saml_token.encode("utf-8")).decode("utf-8"),
             "resource": self.resource_uri,
         }
         if additionaldata:
@@ -854,23 +984,29 @@ class Authentication():
         self.tokendata = self.tokenreply_to_tokendata(tokenreply)
         return self.tokendata
 
-    def authenticate_with_saml_native_v2(self, saml_token, additionaldata=None, returnreply=False, grant_type=GRANT_TYPE_SAML1_1):
+    def authenticate_with_saml_native_v2(
+        self,
+        saml_token,
+        additionaldata=None,
+        returnreply=False,
+        grant_type=GRANT_TYPE_SAML1_1,
+    ):
         """
         Authenticate with a SAML token from the Federation Server
         Native ROADlib implementation without adal requirement
         This function calls identity platform v2 and thus requires a scope instead of resource
         """
-        authority_uri = self.get_authority_url('organizations')
+        authority_uri = self.get_authority_url("organizations")
         data = {
             "client_id": self.client_id,
             "grant_type": grant_type,
-            "assertion": base64.b64encode(saml_token.encode('utf-8')).decode('utf-8'),
+            "assertion": base64.b64encode(saml_token.encode("utf-8")).decode("utf-8"),
             "scope": self.scope,
         }
         if self.use_cae:
             self.set_cae()
         if self.claims:
-            data['claims'] = json.dumps(self.claims)
+            data["claims"] = json.dumps(self.claims)
         if additionaldata:
             data = {**data, **additionaldata}
         res = self.requests_post(f"{authority_uri}/oauth2/v2.0/token", data=data)
@@ -883,72 +1019,98 @@ class Authentication():
         return self.tokendata
 
     def get_desktopsso_token(self, username=None, password=None, krbtoken=None):
-        '''
+        """
         Get desktop SSO token either with plain username and password, or with a Kerberos auth token
-        '''
+        """
         if username and password:
-            rbody = DSSO_BODY_USERPASS.format(username=xml_escape(username), password=xml_escape(password), tenant=self.tenant)
+            rbody = DSSO_BODY_USERPASS.format(
+                username=xml_escape(username),
+                password=xml_escape(password),
+                tenant=self.tenant,
+            )
             headers = {
-                'Content-Type':'application/soap+xml; charset=utf-8',
-                'SOAPAction': 'http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue',
+                "Content-Type": "application/soap+xml; charset=utf-8",
+                "SOAPAction": "http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue",
             }
-            res = self.requests_post(f'https://autologon.microsoftazuread-sso.com/{self.tenant}/winauth/trust/2005/usernamemixed?client-request-id=19ac39db-81d2-4713-8046-b0b7240592be', headers=headers, data=rbody)
+            res = self.requests_post(
+                f"https://autologon.microsoftazuread-sso.com/{self.tenant}/winauth/trust/2005/usernamemixed?client-request-id=19ac39db-81d2-4713-8046-b0b7240592be",
+                headers=headers,
+                data=rbody,
+            )
             tree = ET.fromstring(res.content)
-            els = tree.findall('.//DesktopSsoToken')
+            els = tree.findall(".//DesktopSsoToken")
             if len(els) > 0:
                 token = els[0].text
                 return token
             else:
                 # Try finding error
-                elres = tree.iter('{http://schemas.microsoft.com/Passport/SoapServices/SOAPFault}text')
+                elres = tree.iter(
+                    "{http://schemas.microsoft.com/Passport/SoapServices/SOAPFault}text"
+                )
                 if elres:
                     errtext = next(elres)
                     raise AuthenticationException(errtext.text)
                 else:
-                    raise AuthenticationException(parseString(res.content).toprettyxml(indent='  '))
+                    raise AuthenticationException(
+                        parseString(res.content).toprettyxml(indent="  ")
+                    )
         elif krbtoken:
             rbody = DSSO_BODY_KERBEROS.format(tenant=self.tenant)
             headers = {
-                'Content-Type':'application/soap+xml; charset=utf-8',
-                'SOAPAction': 'http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue',
-                'Authorization': f'Negotiate {krbtoken}'
+                "Content-Type": "application/soap+xml; charset=utf-8",
+                "SOAPAction": "http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue",
+                "Authorization": f"Negotiate {krbtoken}",
             }
-            res = self.requests_post(f'https://autologon.microsoftazuread-sso.com/{self.tenant}/winauth/trust/2005/windowstransport?client-request-id=19ac39db-81d2-4713-8046-b0b7240592be', headers=headers, data=rbody)
+            res = self.requests_post(
+                f"https://autologon.microsoftazuread-sso.com/{self.tenant}/winauth/trust/2005/windowstransport?client-request-id=19ac39db-81d2-4713-8046-b0b7240592be",
+                headers=headers,
+                data=rbody,
+            )
             tree = ET.fromstring(res.content)
-            els = tree.findall('.//DesktopSsoToken')
+            els = tree.findall(".//DesktopSsoToken")
             if len(els) > 0:
                 token = els[0].text
                 return token
             else:
-                print(parseString(res.content).toprettyxml(indent='  '))
+                print(parseString(res.content).toprettyxml(indent="  "))
                 return False
         else:
             return False
 
-    def authenticate_with_desktopsso_token(self, dssotoken, returnreply=False, additionaldata=None):
-        '''
+    def authenticate_with_desktopsso_token(
+        self, dssotoken, returnreply=False, additionaldata=None
+    ):
+        """
         Authenticate with Desktop SSO token
-        '''
+        """
         headers = {
-            'x-client-SKU': 'PCL.Desktop',
-            'x-client-Ver': '3.19.7.16602',
-            'x-client-CPU': 'x64',
-            'x-client-OS': 'Microsoft Windows NT 10.0.18363.0',
-            'x-ms-PKeyAuth': '1.0',
-            'client-request-id': '19ac39db-81d2-4713-8046-b0b7240592be',
-            'return-client-request-id': 'true',
+            "x-client-SKU": "PCL.Desktop",
+            "x-client-Ver": "3.19.7.16602",
+            "x-client-CPU": "x64",
+            "x-client-OS": "Microsoft Windows NT 10.0.18363.0",
+            "x-ms-PKeyAuth": "1.0",
+            "client-request-id": "19ac39db-81d2-4713-8046-b0b7240592be",
+            "return-client-request-id": "true",
         }
-        claim = base64.b64encode('<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion"><DesktopSsoToken>{0}</DesktopSsoToken></saml:Assertion>'.format(dssotoken).encode('utf-8')).decode('utf-8')
+        claim = base64.b64encode(
+            '<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion"><DesktopSsoToken>{0}</DesktopSsoToken></saml:Assertion>'.format(
+                dssotoken
+            ).encode(
+                "utf-8"
+            )
+        ).decode("utf-8")
         data = {
-            'resource': self.resource_uri,
-            'client_id': self.client_id,
-            'grant_type': 'urn:ietf:params:oauth:grant-type:saml1_1-bearer',
-            'assertion': claim,
+            "resource": self.resource_uri,
+            "client_id": self.client_id,
+            "grant_type": "urn:ietf:params:oauth:grant-type:saml1_1-bearer",
+            "assertion": claim,
         }
         authority_uri = self.get_authority_url()
         if additionaldata:
             data = {**data, **additionaldata}
-        res = self.requests_post(f"{authority_uri}/oauth2/token", headers=headers, data=data)
+        res = self.requests_post(
+            f"{authority_uri}/oauth2/token", headers=headers, data=data
+        )
         if res.status_code != 200:
             raise AuthenticationException(res.text)
         tokenreply = res.json()
@@ -961,64 +1123,76 @@ class Authentication():
         body = {
             "pid": str(uuid.uuid4()),
             "name": "bulktoken",
-            "exp": (datetime.datetime.now() + datetime.timedelta(days=90)).strftime('%Y-%m-%d %H:%M:%S')
+            "exp": (datetime.datetime.now() + datetime.timedelta(days=90)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            ),
         }
-        headers = {
-            'Authorization': f'Bearer {access_token}'
-        }
-        url = 'https://login.microsoftonline.com/webapp/bulkaadjtoken/begin'
+        headers = {"Authorization": f"Bearer {access_token}"}
+        url = "https://login.microsoftonline.com/webapp/bulkaadjtoken/begin"
         res = self.requests_post(url, json=body, headers=headers)
         data = res.json()
-        state = data.get('state')
+        state = data.get("state")
         if not state:
-            print(f'No state returned. Server said: {data}')
+            print(f"No state returned. Server said: {data}")
             return False
 
-        if state == 'CompleteError':
+        if state == "CompleteError":
             print(f'Error occurred: {data["resultData"]}')
             return False
 
-        flowtoken = data.get('flowToken')
+        flowtoken = data.get("flowToken")
         if not flowtoken:
-            print(f'Error. No flow token found. Data: {data}')
+            print(f"Error. No flow token found. Data: {data}")
             return False
-        print('Got flow token, polling for token creation')
-        url = 'https://login.microsoftonline.com/webapp/bulkaadjtoken/poll'
+        print("Got flow token, polling for token creation")
+        url = "https://login.microsoftonline.com/webapp/bulkaadjtoken/poll"
         while True:
-            res = self.requests_get(url, params={'flowtoken':flowtoken}, headers=headers)
+            res = self.requests_get(
+                url, params={"flowtoken": flowtoken}, headers=headers
+            )
             data = res.json()
-            state = data.get('state')
+            state = data.get("state")
             if not state:
-                print(f'No state returned. Server said: {data}')
+                print(f"No state returned. Server said: {data}")
                 return False
-            if state == 'CompleteError':
+            if state == "CompleteError":
                 print(f'Error occurred: {data["resultData"]}')
                 return False
-            if state == 'CompleteSuccess':
-                tokenresult = json.loads(data['resultData'])
+            if state == "CompleteSuccess":
+                tokenresult = json.loads(data["resultData"])
                 # The function below needs one so lets supply it
-                tokenresult['access_token'] = tokenresult['id_token']
-                self.tokendata = self.tokenreply_to_tokendata(tokenresult, client_id='b90d5b8f-5503-4153-b545-b31cecfaece2')
+                tokenresult["access_token"] = tokenresult["id_token"]
+                self.tokendata = self.tokenreply_to_tokendata(
+                    tokenresult, client_id="b90d5b8f-5503-4153-b545-b31cecfaece2"
+                )
                 return self.tokendata
             time.sleep(1.0)
 
     def build_auth_url(self, redirurl, response_type, scope=None, state=None):
-        '''
+        """
         Build authorize URL. Can be v2 by specifying scope, otherwise defaults
         to v1 with resource
-        '''
-        urlt_v2 = 'https://login.microsoftonline.com/{3}/oauth2/v2.0/authorize?response_type={4}&client_id={0}&scope={2}&redirect_uri={1}&state={5}'
-        urlt_v1 = 'https://login.microsoftonline.com/{3}/oauth2/authorize?response_type={4}&client_id={0}&resource={2}&redirect_uri={1}&state={5}'
+        """
+        urlt_v2 = "https://login.microsoftonline.com/{3}/oauth2/v2.0/authorize?response_type={4}&client_id={0}&scope={2}&redirect_uri={1}&state={5}"
+        urlt_v1 = "https://login.microsoftonline.com/{3}/oauth2/authorize?response_type={4}&client_id={0}&resource={2}&redirect_uri={1}&state={5}"
         if self.use_pkce:
             if not self.pkce_secret:
                 self.gen_pkce_secret()
-            urlt_v2 = urlt_v2 + '&code_challenge_method=S256&code_challenge=' + quote_plus(self.get_pkce_challenge())
-            urlt_v1 = urlt_v1 + '&code_challenge_method=S256&code_challenge=' + quote_plus(self.get_pkce_challenge())
+            urlt_v2 = (
+                urlt_v2
+                + "&code_challenge_method=S256&code_challenge="
+                + quote_plus(self.get_pkce_challenge())
+            )
+            urlt_v1 = (
+                urlt_v1
+                + "&code_challenge_method=S256&code_challenge="
+                + quote_plus(self.get_pkce_challenge())
+            )
 
         if not state:
             state = str(uuid.uuid4())
         if not self.tenant:
-            tenant = 'common'
+            tenant = "common"
         else:
             tenant = self.tenant
         if scope:
@@ -1026,7 +1200,7 @@ class Authentication():
             if self.use_cae:
                 self.set_cae()
             if self.claims:
-                urlt_v2 = urlt_v2 + '&claims=' + quote_plus(json.dumps(self.claims))
+                urlt_v2 = urlt_v2 + "&claims=" + quote_plus(json.dumps(self.claims))
             if self.use_pkce:
                 if not self.pkce_secret:
                     self.gen_pkce_secret()
@@ -1037,10 +1211,10 @@ class Authentication():
                 quote_plus(scope),
                 quote_plus(tenant),
                 quote_plus(response_type),
-                quote_plus(state)
+                quote_plus(state),
             )
         if self.has_force_mfa():
-            urlt_v1 += '&amr_values=ngcmfa'
+            urlt_v1 += "&amr_values=ngcmfa"
         # Else default to v1 identity endpoint
         return urlt_v1.format(
             quote_plus(self.client_id),
@@ -1048,7 +1222,7 @@ class Authentication():
             quote_plus(self.resource_uri),
             quote_plus(tenant),
             quote_plus(response_type),
-            quote_plus(state)
+            quote_plus(state),
         )
 
     def create_prt_cookie_kdf_ver_2(self, prt, sessionkey, nonce=None):
@@ -1057,8 +1231,8 @@ class Authentication():
         """
         context = os.urandom(24)
         headers = {
-            'ctx': base64.b64encode(context).decode('utf-8'), #.rstrip('=')
-            'kdf_ver': 2
+            "ctx": base64.b64encode(context).decode("utf-8"),  # .rstrip('=')
+            "kdf_ver": 2,
         }
         # Nonce should be requested by calling function, otherwise
         # old time based model is used
@@ -1066,22 +1240,24 @@ class Authentication():
             payload = {
                 "refresh_token": prt,
                 "is_primary": "true",
-                "request_nonce": nonce
+                "request_nonce": nonce,
             }
         else:
             payload = {
                 "refresh_token": prt,
                 "is_primary": "true",
-                "iat": str(int(time.time()))
+                "iat": str(int(time.time())),
             }
         # Sign with random key just to get jwt body in right encoding
-        tempjwt = jwt.encode(payload, os.urandom(32), algorithm='HS256', headers=headers)
-        jbody = tempjwt.split('.')[1]
-        jwtbody = base64.b64decode(jbody+('='*(len(jbody)%4)))
+        tempjwt = jwt.encode(
+            payload, os.urandom(32), algorithm="HS256", headers=headers
+        )
+        jbody = tempjwt.split(".")[1]
+        jwtbody = base64.b64decode(jbody + ("=" * (len(jbody) % 4)))
 
         # Now calculate the derived key based on random context plus jwt body
         _, derived_key = self.calculate_derived_key_v2(sessionkey, context, jwtbody)
-        cookie = jwt.encode(payload, derived_key, algorithm='HS256', headers=headers)
+        cookie = jwt.encode(payload, derived_key, algorithm="HS256", headers=headers)
         return cookie
 
     def authenticate_with_prt_v2(self, prt, sessionkey):
@@ -1105,17 +1281,13 @@ class Authentication():
             context, derived_key = self.calculate_derived_key(sessionkey, context)
 
         headers = {
-            'ctx': base64.b64encode(context).decode('utf-8'),
+            "ctx": base64.b64encode(context).decode("utf-8"),
         }
         nonce = self.get_srv_challenge_nonce()
         if not nonce:
             return False
-        payload = {
-            "refresh_token": prt,
-            "is_primary": "true",
-            "request_nonce": nonce
-        }
-        cookie = jwt.encode(payload, derived_key, algorithm='HS256', headers=headers)
+        payload = {"refresh_token": prt, "is_primary": "true", "request_nonce": nonce}
+        cookie = jwt.encode(payload, derived_key, algorithm="HS256", headers=headers)
         return self.authenticate_with_prt_cookie(cookie)
 
     def calculate_derived_key_v2(self, sessionkey, context, jwtbody):
@@ -1147,7 +1319,7 @@ class Authentication():
             label=label,
             context=context,
             fixed=None,
-            backend=backend
+            backend=backend,
         )
         derived_key = kdf.derive(sessionkey)
         return context, derived_key
@@ -1163,15 +1335,21 @@ class Authentication():
                 return json.loads(responsedata)
             return responsedata
         # Encrypted Key doesn't appear to be used, instead the key is the decrypted ciphertext
-        #pylint: disable=unused-variable
-        headerdata, enckey, iv, ciphertext, authtag = responsedata.split('.')
+        # pylint: disable=unused-variable
+        headerdata, enckey, iv, ciphertext, authtag = responsedata.split(".")
 
         headers = json.loads(get_data(headerdata))
-        _, derived_key = self.calculate_derived_key(sessionkey, base64.b64decode(headers['ctx']))
+        _, derived_key = self.calculate_derived_key(
+            sessionkey, base64.b64decode(headers["ctx"])
+        )
 
-        return self.decrypt_auth_response_derivedkey(headerdata, ciphertext, iv, authtag, derived_key, asjson)
+        return self.decrypt_auth_response_derivedkey(
+            headerdata, ciphertext, iv, authtag, derived_key, asjson
+        )
 
-    def decrypt_auth_response_derivedkey(self, headerdata, ciphertext, iv, authtag, derived_key, asjson=False):
+    def decrypt_auth_response_derivedkey(
+        self, headerdata, ciphertext, iv, authtag, derived_key, asjson=False
+    ):
         """
         Decrypt an encrypted authentication response, using the derived key
         """
@@ -1181,11 +1359,17 @@ class Authentication():
             # JWE header is used as additional data
             # Totally legit source: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/compare/dev...kedicl/swift/addframework#diff-ec15357c1b0dba2f2304f64750e5126ec910156f09c0f75eba0bb22cb83ada6dR46
             # Also hinted at in RFC examples https://www.rfc-editor.org/rfc/rfc7516.txt
-            depadded_data = aesgcm.decrypt(get_data(iv), get_data(ciphertext) + get_data(authtag), headerdata.encode('utf-8'))
+            depadded_data = aesgcm.decrypt(
+                get_data(iv),
+                get_data(ciphertext) + get_data(authtag),
+                headerdata.encode("utf-8"),
+            )
         else:
             cipher = Cipher(algorithms.AES(derived_key), modes.CBC(get_data(iv)))
             decryptor = cipher.decryptor()
-            decrypted_data = decryptor.update(get_data(ciphertext)) + decryptor.finalize()
+            decrypted_data = (
+                decryptor.update(get_data(ciphertext)) + decryptor.finalize()
+            )
             unpadder = padding.PKCS7(128).unpadder()
             depadded_data = unpadder.update(decrypted_data) + unpadder.finalize()
         if asjson:
@@ -1199,8 +1383,10 @@ class Authentication():
         Request server challenge (nonce) to use with a PRT
         Returns Nonce as a dict {'Nonce':data}
         """
-        data = {'grant_type':'srv_challenge'}
-        res = self.requests_post('https://login.microsoftonline.com/common/oauth2/token', data=data)
+        data = {"grant_type": "srv_challenge"}
+        res = self.requests_post(
+            "https://login.microsoftonline.com/common/oauth2/token", data=data
+        )
         return res.json()
 
     def get_srv_challenge_nonce(self):
@@ -1208,7 +1394,7 @@ class Authentication():
         Request server challenge (nonce) to use with a PRT
         Returns Nonce as string
         """
-        return self.get_srv_challenge()['Nonce']
+        return self.get_srv_challenge()["Nonce"]
 
     def get_prt_cookie_nonce(self):
         """
@@ -1218,73 +1404,88 @@ class Authentication():
         This function is not used anymore but is still here for compatibility purposes
         """
         params = {
-            'resource': self.resource_uri,
-            'client_id': self.client_id,
-            'response_type': 'code',
-            'haschrome': '1',
-            'redirect_uri': 'https://login.microsoftonline.com/common/oauth2/nativeclient',
-            'client-request-id': str(uuid.uuid4()),
-            'x-client-SKU': 'PCL.Desktop',
-            'x-client-Ver': '3.19.7.16602',
-            'x-client-CPU': 'x64',
-            'x-client-OS': 'Microsoft Windows NT 10.0.19569.0',
-            'site_id': 501358,
-            'mscrid': str(uuid.uuid4())
+            "resource": self.resource_uri,
+            "client_id": self.client_id,
+            "response_type": "code",
+            "haschrome": "1",
+            "redirect_uri": "https://login.microsoftonline.com/common/oauth2/nativeclient",
+            "client-request-id": str(uuid.uuid4()),
+            "x-client-SKU": "PCL.Desktop",
+            "x-client-Ver": "3.19.7.16602",
+            "x-client-CPU": "x64",
+            "x-client-OS": "Microsoft Windows NT 10.0.19569.0",
+            "site_id": 501358,
+            "mscrid": str(uuid.uuid4()),
         }
         headers = {
-            'User-Agent': 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 10.0; Win64; x64; Trident/7.0; .NET4.0C; .NET4.0E)',
-            'UA-CPU': 'AMD64',
+            "User-Agent": "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 10.0; Win64; x64; Trident/7.0; .NET4.0C; .NET4.0E)",
+            "UA-CPU": "AMD64",
         }
-        res = self.requests_get('https://login.microsoftonline.com/Common/oauth2/authorize', params=params, headers=headers, allow_redirects=False)
+        res = self.requests_get(
+            "https://login.microsoftonline.com/Common/oauth2/authorize",
+            params=params,
+            headers=headers,
+            allow_redirects=False,
+        )
         if self.debug:
-            with open('roadtools.debug.html','w') as outfile:
+            with open("roadtools.debug.html", "w") as outfile:
                 outfile.write(str(res.headers))
-                outfile.write('------\n\n\n-----')
-                outfile.write(res.content.decode('utf-8'))
-        if res.status_code == 302 and res.headers['Location']:
-            ups = urlparse(res.headers['Location'])
+                outfile.write("------\n\n\n-----")
+                outfile.write(res.content.decode("utf-8"))
+        if res.status_code == 302 and res.headers["Location"]:
+            ups = urlparse(res.headers["Location"])
             qdata = parse_qs(ups.query)
-            if not 'sso_nonce' in qdata:
-                print('No nonce found in redirect!')
+            if not "sso_nonce" in qdata:
+                print("No nonce found in redirect!")
                 return
-            return qdata['sso_nonce'][0]
+            return qdata["sso_nonce"][0]
         else:
             # Try to find SSO nonce in json config
-            startpos = res.content.find(b'$Config=')
-            stoppos = res.content.find(b'//]]></script>')
+            startpos = res.content.find(b"$Config=")
+            stoppos = res.content.find(b"//]]></script>")
             if startpos == -1 or stoppos == -1:
-                print('No redirect or nonce config was returned!')
+                print("No redirect or nonce config was returned!")
                 return
             else:
-                jsonbytes = res.content[startpos+8:stoppos-2]
+                jsonbytes = res.content[startpos + 8 : stoppos - 2]
                 try:
                     jdata = json.loads(jsonbytes)
                 except json.decoder.JSONDecodeError:
-                    print('Failed to parse config JSON')
+                    print("Failed to parse config JSON")
                 try:
-                    nonce = jdata['bsso']['nonce']
+                    nonce = jdata["bsso"]["nonce"]
                 except KeyError:
-                    print('No nonce found in browser config')
+                    print("No nonce found in browser config")
                     return
                 return nonce
 
-
-    def authenticate_with_prt_cookie(self, cookie, context=None, derived_key=None, verify_only=False, sessionkey=None, redirurl=None, return_code=False):
+    def authenticate_with_prt_cookie(
+        self,
+        cookie,
+        context=None,
+        derived_key=None,
+        verify_only=False,
+        sessionkey=None,
+        redirurl=None,
+        return_code=False,
+    ):
         """
         Authenticate with a PRT cookie, optionally re-signing the cookie if a key is given
         """
         # Load cookie
-        jdata = jwt.decode(cookie, options={"verify_signature":False}, algorithms=['HS256'])
+        jdata = jwt.decode(
+            cookie, options={"verify_signature": False}, algorithms=["HS256"]
+        )
         # Does it have a nonce?
-        if not 'request_nonce' in jdata:
+        if not "request_nonce" in jdata:
             nonce = self.get_srv_challenge_nonce()
             if not nonce:
                 return False
-            print('Requested nonce from server to use with ROADtoken: %s' % nonce)
+            print("Requested nonce from server to use with ROADtoken: %s" % nonce)
             if not derived_key and not sessionkey:
                 return False
         else:
-            nonce = jdata['request_nonce']
+            nonce = jdata["request_nonce"]
 
         # If raw key specified, use that
         if not derived_key and sessionkey:
@@ -1297,117 +1498,129 @@ class Authentication():
             if context is None or verify_only:
                 # Verify JWT
                 try:
-                    jdata = jwt.decode(cookie, sdata, algorithms=['HS256'])
+                    jdata = jwt.decode(cookie, sdata, algorithms=["HS256"])
                 except jwt.exceptions.InvalidSignatureError:
-                    print('Signature invalid with given derived key')
+                    print("Signature invalid with given derived key")
                     return False
                 if verify_only:
-                    print('PRT verified with given derived key!')
+                    print("PRT verified with given derived key!")
                     return False
             else:
                 # Don't verify JWT, just load it
-                jdata = jwt.decode(cookie, sdata, options={"verify_signature":False}, algorithms=['HS256'])
+                jdata = jwt.decode(
+                    cookie,
+                    sdata,
+                    options={"verify_signature": False},
+                    algorithms=["HS256"],
+                )
             # Since a derived key was specified, we get a new nonce
             nonce = self.get_srv_challenge_nonce()
-            jdata['request_nonce'] = nonce
+            jdata["request_nonce"] = nonce
             if context:
                 # Resign with custom context, should be in base64
                 newheaders = {
-                    'ctx': base64.b64encode(context).decode('utf-8') #.rstrip('=')
+                    "ctx": base64.b64encode(context).decode("utf-8")  # .rstrip('=')
                 }
-                cookie = jwt.encode(jdata, sdata, algorithm='HS256', headers=newheaders)
-                print('Re-signed PRT cookie using custom context')
+                cookie = jwt.encode(jdata, sdata, algorithm="HS256", headers=newheaders)
+                print("Re-signed PRT cookie using custom context")
             else:
-                newheaders = {
-                    'ctx': headers['ctx']
-                }
-                cookie = jwt.encode(jdata, sdata, algorithm='HS256', headers=newheaders)
-                print('Re-signed PRT cookie using derived key')
+                newheaders = {"ctx": headers["ctx"]}
+                cookie = jwt.encode(jdata, sdata, algorithm="HS256", headers=newheaders)
+                print("Re-signed PRT cookie using derived key")
 
         ses = requests.session()
         ses.proxies = self.proxies
         ses.verify = self.verify
         if self.user_agent:
-            headers = {'User-Agent': self.user_agent}
+            headers = {"User-Agent": self.user_agent}
             ses.headers = headers
         authority_uri = self.get_authority_url()
         params = {
-            'client_id': self.client_id,
-            'response_type': 'code',
-            'haschrome': '1',
-            'redirect_uri': 'https://login.microsoftonline.com/common/oauth2/nativeclient',
-            'client-request-id': str(uuid.uuid4()),
-            'x-client-SKU': 'PCL.Desktop',
-            'x-client-Ver': '3.19.7.16602',
-            'x-client-CPU': 'x64',
-            'x-client-OS': 'Microsoft Windows NT 10.0.19569.0',
-            'site_id': 501358,
-            'sso_nonce': nonce,
-            'mscrid': str(uuid.uuid4())
+            "client_id": self.client_id,
+            "response_type": "code",
+            "haschrome": "1",
+            "redirect_uri": "https://login.microsoftonline.com/common/oauth2/nativeclient",
+            "client-request-id": str(uuid.uuid4()),
+            "x-client-SKU": "PCL.Desktop",
+            "x-client-Ver": "3.19.7.16602",
+            "x-client-CPU": "x64",
+            "x-client-OS": "Microsoft Windows NT 10.0.19569.0",
+            "site_id": 501358,
+            "sso_nonce": nonce,
+            "mscrid": str(uuid.uuid4()),
         }
         if self.scope:
             # Switch to identity platform v2 endpoint
-            params['scope'] = self.scope
-            url = f'{authority_uri}/oauth2/v2.0/authorize'
+            params["scope"] = self.scope
+            url = f"{authority_uri}/oauth2/v2.0/authorize"
             coderedeemfunc = self.authenticate_with_code_native_v2
         else:
-            params['resource'] = self.resource_uri
-            url = f'{authority_uri}/oauth2/authorize'
+            params["resource"] = self.resource_uri
+            url = f"{authority_uri}/oauth2/authorize"
             coderedeemfunc = self.authenticate_with_code_native
 
         headers = {
-            'UA-CPU': 'AMD64',
+            "UA-CPU": "AMD64",
         }
         if not self.user_agent:
             # Add proper user agent if we don't have one yet
-            headers['User-Agent'] = 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 10.0; Win64; x64; Trident/7.0; .NET4.0C; .NET4.0E)'
+            headers["User-Agent"] = (
+                "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 10.0; Win64; x64; Trident/7.0; .NET4.0C; .NET4.0E)"
+            )
 
-        cookies = {
-            'x-ms-RefreshTokenCredential': cookie
-        }
+        cookies = {"x-ms-RefreshTokenCredential": cookie}
         if redirurl:
-            params['redirect_uri'] = redirurl
+            params["redirect_uri"] = redirurl
 
-        res = ses.get(url, params=params, headers=headers, cookies=cookies, allow_redirects=False)
-        if res.status_code == 302 and params['redirect_uri'].lower() in res.headers['Location'].lower():
-            ups = urlparse(res.headers['Location'])
+        res = ses.get(
+            url, params=params, headers=headers, cookies=cookies, allow_redirects=False
+        )
+        if (
+            res.status_code == 302
+            and params["redirect_uri"].lower() in res.headers["Location"].lower()
+        ):
+            ups = urlparse(res.headers["Location"])
             qdata = parse_qs(ups.query)
             # Return code if requested, otherwise redeem it
             if return_code:
-                return qdata['code'][0]
-            return coderedeemfunc(qdata['code'][0], params['redirect_uri'])
-        if res.status_code == 302 and 'sso_nonce' in res.headers['Location'].lower():
-            ups = urlparse(res.headers['Location'])
+                return qdata["code"][0]
+            return coderedeemfunc(qdata["code"][0], params["redirect_uri"])
+        if res.status_code == 302 and "sso_nonce" in res.headers["Location"].lower():
+            ups = urlparse(res.headers["Location"])
             qdata = parse_qs(ups.query)
-            if 'sso_nonce' in qdata:
-                nonce = qdata['sso_nonce'][0]
-                print(f'Redirected with new nonce. Old nonce may be expired. New nonce: {nonce}')
+            if "sso_nonce" in qdata:
+                nonce = qdata["sso_nonce"][0]
+                print(
+                    f"Redirected with new nonce. Old nonce may be expired. New nonce: {nonce}"
+                )
         if self.debug:
-            with open('roadtools.debug.html','w') as outfile:
+            with open("roadtools.debug.html", "w") as outfile:
                 outfile.write(str(res.headers))
-                outfile.write('------\n\n\n-----')
-                outfile.write(res.content.decode('utf-8'))
+                outfile.write("------\n\n\n-----")
+                outfile.write(res.content.decode("utf-8"))
 
         # Try to find SSO nonce in json config
-        startpos = res.content.find(b'$Config=')
-        stoppos = res.content.find(b'//]]></script>')
+        startpos = res.content.find(b"$Config=")
+        stoppos = res.content.find(b"//]]></script>")
         if startpos != -1 and stoppos != -1:
-            jsonbytes = res.content[startpos+8:stoppos-2]
+            jsonbytes = res.content[startpos + 8 : stoppos - 2]
             try:
                 jdata = json.loads(jsonbytes)
                 try:
-                    error = jdata['strMainMessage']
-                    print(f'Error from STS: {error}')
-                    error = jdata['strAdditionalMessage']
-                    print(f'Additional info: {error}')
-                    error = jdata['strServiceExceptionMessage']
-                    print(f'Exception: {error}')
+                    error = jdata["strMainMessage"]
+                    print(f"Error from STS: {error}")
+                    error = jdata["strAdditionalMessage"]
+                    print(f"Additional info: {error}")
+                    error = jdata["strServiceExceptionMessage"]
+                    print(f"Exception: {error}")
                 except KeyError:
                     pass
             except json.decoder.JSONDecodeError:
                 pass
-        print('No authentication code was returned, make sure the PRT cookie is valid')
-        print('It is also possible that the sign-in was blocked by Conditional Access policies')
+        print("No authentication code was returned, make sure the PRT cookie is valid")
+        print(
+            "It is also possible that the sign-in was blocked by Conditional Access policies"
+        )
         return False
 
     @staticmethod
@@ -1415,109 +1628,145 @@ class Authentication():
         """
         Get an argparse subparser for authentication
         """
-        auth_parser.add_argument('-u',
-                                 '--username',
-                                 action='store',
-                                 help='Username for authentication')
-        auth_parser.add_argument('-p',
-                                 '--password',
-                                 action='store',
-                                 help='Password (leave empty to prompt)')
-        auth_parser.add_argument('-t',
-                                 '--tenant',
-                                 action='store',
-                                 help='Tenant ID to auth to (leave blank for default tenant for account)')
+        auth_parser.add_argument(
+            "-u", "--username", action="store", help="Username for authentication"
+        )
+        auth_parser.add_argument(
+            "-p", "--password", action="store", help="Password (leave empty to prompt)"
+        )
+        auth_parser.add_argument(
+            "-t",
+            "--tenant",
+            action="store",
+            help="Tenant ID to auth to (leave blank for default tenant for account)",
+        )
         if for_rr:
-            helptext = 'Client ID to use when authenticating. (Must be a public client from Microsoft with user_impersonation permissions!). Default: Azure AD PowerShell module App ID'
+            helptext = "Client ID to use when authenticating. (Must be a public client from Microsoft with user_impersonation permissions!). Default: Azure AD PowerShell module App ID"
         else:
-            helptext = 'Client ID to use when authenticating. (Must have the required OAuth2 permissions or Application Role for what you want to achieve)'
-        auth_parser.add_argument('-c',
-                                 '--client',
-                                 action='store',
-                                 help=helptext,
-                                 default='1b730954-1685-4b74-9bfd-dac224a7b894')
-        auth_parser.add_argument('-r',
-                                 '--resource',
-                                 action='store',
-                                 help='Resource to authenticate to (Default: https://graph.windows.net)',
-                                 default='https://graph.windows.net')
-        auth_parser.add_argument('-s',
-                                 '--scope',
-                                 action='store',
-                                 help='Scope to request when authenticating. Not supported in all flows yet. Overrides resource if specified')
-        auth_parser.add_argument('--as-app',
-                                 action='store_true',
-                                 help='Authenticate as App (requires password and client ID set)')
-        auth_parser.add_argument('--device-code',
-                                 action='store_true',
-                                 help='Authenticate using a device code')
-        auth_parser.add_argument('--access-token',
-                                 action='store',
-                                 help='Access token (JWT)')
-        auth_parser.add_argument('--refresh-token',
-                                 action='store',
-                                 help='Refresh token (or the word "file" to read it from .roadtools_auth)')
-        auth_parser.add_argument('--origin',
-                                 action='store',
-                                 help='Origin of a browser refresh token from a Single Page Application (i.e. "https://portal.azure.com"). Used with Azure portal or other portal refresh tokens when combind with a client id like -c c44b4083-3bb0-49c1-b47d-974e53cbdf3c.')
-        auth_parser.add_argument('--saml-token',
-                                 action='store',
-                                 help='SAML token from Federation Server')
-        auth_parser.add_argument('--prt-cookie',
-                                 action='store',
-                                 help='Primary Refresh Token cookie from ROADtoken (JWT)')
-        auth_parser.add_argument('--prt-init',
-                                 action='store_true',
-                                 help='Initialize Primary Refresh Token authentication flow (get nonce)')
-        auth_parser.add_argument('--prt',
-                                 action='store',
-                                 help='Primary Refresh Token')
-        auth_parser.add_argument('--derived-key',
-                                 action='store',
-                                 help='Derived key used to re-sign the PRT cookie (as hex key)')
-        auth_parser.add_argument('--prt-context',
-                                 action='store',
-                                 help='Primary Refresh Token context for the derived key (as hex key)')
-        auth_parser.add_argument('--prt-sessionkey',
-                                 action='store',
-                                 help='Primary Refresh Token session key (as hex key)')
-        auth_parser.add_argument('--prt-verify',
-                                 action='store_true',
-                                 help='Verify the Primary Refresh Token and exit')
-        auth_parser.add_argument('--kdf-v1',
-                                 action='store_true',
-                                 help='Use the older KDF version for PRT auth, may not work with PRTs from modern OSs')
-        auth_parser.add_argument('-ua',
-                                 '--user-agent',
-                                 action='store',
-                                 help='User agent or UA alias to use when requesting tokens (default: python-requests/version)')
-        auth_parser.add_argument('--cae',
-                                 action='store_true',
-                                 help='Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)')
-        auth_parser.add_argument('--force-mfa',
-                                 action='store_true',
-                                 help='Force MFA during authentication')
-        auth_parser.add_argument('--force-ngcmfa',
-                                 action='store_true',
-                                 help='Force NGC MFA (fresh MFA) during authentication')
-        auth_parser.add_argument('-f',
-                                 '--tokenfile',
-                                 action='store',
-                                 help='File to save the tokens to (default: .roadtools_auth)',
-                                 default='.roadtools_auth')
-        auth_parser.add_argument('--tokens-stdout',
-                                 action='store_true',
-                                 help='Do not store tokens on disk, pipe to stdout instead')
-        auth_parser.add_argument('--debug',
-                                 action='store_true',
-                                 help='Enable debug logging to disk')
+            helptext = "Client ID to use when authenticating. (Must have the required OAuth2 permissions or Application Role for what you want to achieve)"
+        auth_parser.add_argument(
+            "-c",
+            "--client",
+            action="store",
+            help=helptext,
+            default="1b730954-1685-4b74-9bfd-dac224a7b894",
+        )
+        auth_parser.add_argument(
+            "-r",
+            "--resource",
+            action="store",
+            help="Resource to authenticate to (Default: https://graph.windows.net)",
+            default="https://graph.windows.net",
+        )
+        auth_parser.add_argument(
+            "-s",
+            "--scope",
+            action="store",
+            help="Scope to request when authenticating. Not supported in all flows yet. Overrides resource if specified",
+        )
+        auth_parser.add_argument(
+            "--as-app",
+            action="store_true",
+            help="Authenticate as App (requires password and client ID set)",
+        )
+        auth_parser.add_argument(
+            "--device-code",
+            action="store_true",
+            help="Authenticate using a device code",
+        )
+        auth_parser.add_argument(
+            "--access-token", action="store", help="Access token (JWT)"
+        )
+        auth_parser.add_argument(
+            "--refresh-token",
+            action="store",
+            help='Refresh token (or the word "file" to read it from .roadtools_auth)',
+        )
+        auth_parser.add_argument(
+            "--origin",
+            action="store",
+            help='Origin of a browser refresh token from a Single Page Application (i.e. "https://portal.azure.com"). Used with Azure portal or other portal refresh tokens when combind with a client id like -c c44b4083-3bb0-49c1-b47d-974e53cbdf3c.',
+        )
+        auth_parser.add_argument(
+            "--saml-token", action="store", help="SAML token from Federation Server"
+        )
+        auth_parser.add_argument(
+            "--prt-cookie",
+            action="store",
+            help="Primary Refresh Token cookie from ROADtoken (JWT)",
+        )
+        auth_parser.add_argument(
+            "--prt-init",
+            action="store_true",
+            help="Initialize Primary Refresh Token authentication flow (get nonce)",
+        )
+        auth_parser.add_argument("--prt", action="store", help="Primary Refresh Token")
+        auth_parser.add_argument(
+            "--derived-key",
+            action="store",
+            help="Derived key used to re-sign the PRT cookie (as hex key)",
+        )
+        auth_parser.add_argument(
+            "--prt-context",
+            action="store",
+            help="Primary Refresh Token context for the derived key (as hex key)",
+        )
+        auth_parser.add_argument(
+            "--prt-sessionkey",
+            action="store",
+            help="Primary Refresh Token session key (as hex key)",
+        )
+        auth_parser.add_argument(
+            "--prt-verify",
+            action="store_true",
+            help="Verify the Primary Refresh Token and exit",
+        )
+        auth_parser.add_argument(
+            "--kdf-v1",
+            action="store_true",
+            help="Use the older KDF version for PRT auth, may not work with PRTs from modern OSs",
+        )
+        auth_parser.add_argument(
+            "-ua",
+            "--user-agent",
+            action="store",
+            help="User agent or UA alias to use when requesting tokens (default: python-requests/version)",
+        )
+        auth_parser.add_argument(
+            "--cae",
+            action="store_true",
+            help="Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)",
+        )
+        auth_parser.add_argument(
+            "--force-mfa", action="store_true", help="Force MFA during authentication"
+        )
+        auth_parser.add_argument(
+            "--force-ngcmfa",
+            action="store_true",
+            help="Force NGC MFA (fresh MFA) during authentication",
+        )
+        auth_parser.add_argument(
+            "-f",
+            "--tokenfile",
+            action="store",
+            help="File to save the tokens to (default: .roadtools_auth)",
+            default=".roadtools_auth",
+        )
+        auth_parser.add_argument(
+            "--tokens-stdout",
+            action="store_true",
+            help="Do not store tokens on disk, pipe to stdout instead",
+        )
+        auth_parser.add_argument(
+            "--debug", action="store_true", help="Enable debug logging to disk"
+        )
         return auth_parser
 
     @staticmethod
     def ensure_binary_derivedkey(derived_key):
         if not derived_key:
             return None
-        secret = derived_key.replace(' ','')
+        secret = derived_key.replace(" ", "")
         sdata = binascii.unhexlify(secret)
         return sdata
 
@@ -1526,9 +1775,9 @@ class Authentication():
         if not sessionkey:
             return None
         # See if this is a base64 string that should be padded
-        padding_needed = len(sessionkey)%4
+        padding_needed = len(sessionkey) % 4
         if padding_needed:
-            esklen = len(sessionkey+('='*(4-padding_needed)))
+            esklen = len(sessionkey + ("=" * (4 - padding_needed)))
         else:
             esklen = len(sessionkey)
         if esklen == 44:
@@ -1536,7 +1785,7 @@ class Authentication():
             # get_data handles both web encoded and regular encoded data
             keybytes = get_data(sessionkey)
         else:
-            sessionkey = sessionkey.replace(' ','')
+            sessionkey = sessionkey.replace(" ", "")
             keybytes = binascii.unhexlify(sessionkey)
         return keybytes
 
@@ -1551,20 +1800,22 @@ class Authentication():
         if not prt:
             return None
         # May be base64 encoded
-        if not '.' in prt:
-            prt = base64.b64decode(prt+('='*(len(prt)%4))).decode('utf-8')
+        if not "." in prt:
+            prt = base64.b64decode(prt + ("=" * (len(prt) % 4))).decode("utf-8")
         return prt
 
     @staticmethod
     def parse_accesstoken(token):
-        tokenparts = token.split('.')
+        tokenparts = token.split(".")
         tokendata = json.loads(get_data(tokenparts[1]))
         tokenobject = {
-            'accessToken': token,
-            'tokenType': 'Bearer',
-            'expiresOn': datetime.datetime.fromtimestamp(tokendata['exp']).strftime('%Y-%m-%d %H:%M:%S'),
-            'tenantId': tokendata.get('tid'),
-            '_clientId': tokendata.get('appid')
+            "accessToken": token,
+            "tokenType": "Bearer",
+            "expiresOn": datetime.datetime.fromtimestamp(tokendata["exp"]).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            ),
+            "tenantId": tokendata.get("tid"),
+            "_clientId": tokendata.get("appid"),
         }
         return tokenobject, tokendata
 
@@ -1574,37 +1825,44 @@ class Authentication():
         Convert /token reply from Azure to ADAL compatible object
         """
         tokenobject = {
-            'tokenType': tokenreply['token_type'],
+            "tokenType": tokenreply["token_type"],
         }
         try:
-            tokenobject['expiresOn'] = datetime.datetime.fromtimestamp(int(tokenreply['expires_on'])).strftime('%Y-%m-%d %H:%M:%S')
+            tokenobject["expiresOn"] = datetime.datetime.fromtimestamp(
+                int(tokenreply["expires_on"])
+            ).strftime("%Y-%m-%d %H:%M:%S")
         except KeyError:
-            tokenobject['expiresOn'] = (datetime.datetime.now() + datetime.timedelta(seconds=int(tokenreply['expires_in']))).strftime('%Y-%m-%d %H:%M:%S')
+            tokenobject["expiresOn"] = (
+                datetime.datetime.now()
+                + datetime.timedelta(seconds=int(tokenreply["expires_in"]))
+            ).strftime("%Y-%m-%d %H:%M:%S")
 
-        tokenparts = tokenreply['access_token'].split('.')
-        inputdata = json.loads(base64.urlsafe_b64decode(tokenparts[1]+('='*(len(tokenparts[1])%4))))
+        tokenparts = tokenreply["access_token"].split(".")
+        inputdata = json.loads(
+            base64.urlsafe_b64decode(tokenparts[1] + ("=" * (len(tokenparts[1]) % 4)))
+        )
         try:
-            tokenobject['tenantId'] = inputdata['tid']
+            tokenobject["tenantId"] = inputdata["tid"]
         except KeyError:
             pass
         if client_id:
-            tokenobject['_clientId'] = client_id
+            tokenobject["_clientId"] = client_id
         else:
             try:
-                tokenobject['_clientId'] = inputdata['appid']
+                tokenobject["_clientId"] = inputdata["appid"]
             except KeyError:
                 pass
         translate_map = {
-            'access_token': 'accessToken',
-            'refresh_token': 'refreshToken',
-            'id_token': 'idToken',
-            'token_type': 'tokenType'
+            "access_token": "accessToken",
+            "refresh_token": "refreshToken",
+            "id_token": "idToken",
+            "token_type": "tokenType",
         }
         for newname, oldname in translate_map.items():
             if newname in tokenreply:
                 tokenobject[oldname] = tokenreply[newname]
-        if 'expires_in' in tokenreply:
-            tokenobject['expiresIn'] = int(tokenreply['expires_in'])
+        if "expires_in" in tokenreply:
+            tokenobject["expiresIn"] = int(tokenreply["expires_in"])
         return tokenobject
 
     @staticmethod
@@ -1613,7 +1871,7 @@ class Authentication():
         Parse compact JWE according to
         https://datatracker.ietf.org/doc/html/rfc7516#section-3.1
         """
-        dataparts = jwe.split('.')
+        dataparts = jwe.split(".")
         header, enc_key, iv, ciphertext, auth_tag = dataparts
         parsed_header = json.loads(get_data(header))
         if verbose:
@@ -1621,7 +1879,7 @@ class Authentication():
             print(json.dumps(parsed_header, sort_keys=True, indent=4))
             print("Encrypted key:")
             print(enc_key)
-            print('IV:')
+            print("IV:")
             print(iv)
             print("Ciphertext:")
             print(ciphertext)
@@ -1637,7 +1895,7 @@ class Authentication():
         Simple JWT parsing function
         returns header and body as dict and signature as bytes
         """
-        dataparts = jwtoken.split('.')
+        dataparts = jwtoken.split(".")
         header = json.loads(get_data(dataparts[0]))
         body = json.loads(get_data(dataparts[1]))
         signature = get_data(dataparts[2])
@@ -1661,22 +1919,22 @@ class Authentication():
         Supports multiple scopes, eg "msgraph/.default offline_access"
         """
         outscopes = []
-        for scope in scopes.split(' '):
-            if '/' in scope:
+        for scope in scopes.split(" "):
+            if "/" in scope:
                 # Full specifier
-                resource, rscope = scope.rsplit('/', 1)
+                resource, rscope = scope.rsplit("/", 1)
                 try:
                     resolved = WELLKNOWN_RESOURCES[resource.lower()]
                     # Strip trailing / if there for aliases
-                    if resolved[-1] == '/':
+                    if resolved[-1] == "/":
                         resolved = resolved[:-1]
                 except KeyError:
                     resolved = resource
-                outscopes.append('/'.join([resolved, rscope]))
+                outscopes.append("/".join([resolved, rscope]))
             else:
                 # Just a scope, no resource
                 outscopes.append(scope)
-        return ' '.join(outscopes)
+        return " ".join(outscopes)
 
     @staticmethod
     def lookup_client_id(clid):
@@ -1696,7 +1954,7 @@ class Authentication():
         """
         if useragent is None:
             return useragent
-        if useragent.upper() == 'EMPTY':
+        if useragent.upper() == "EMPTY":
             return SKIP_HEADER
         try:
             resolved = WELLKNOWN_USER_AGENTS[useragent.lower()]
@@ -1705,31 +1963,31 @@ class Authentication():
             return useragent
 
     def requests_get(self, *args, **kwargs):
-        '''
+        """
         Wrapper around requests.get to set all the options uniformly
-        '''
-        kwargs['proxies'] = self.proxies
-        kwargs['verify'] = self.verify
+        """
+        kwargs["proxies"] = self.proxies
+        kwargs["verify"] = self.verify
         if self.user_agent:
-            headers = kwargs.get('headers',{})
-            headers['User-Agent'] = self.user_agent
-            kwargs['headers'] = headers
+            headers = kwargs.get("headers", {})
+            headers["User-Agent"] = self.user_agent
+            kwargs["headers"] = headers
         return requests.get(*args, timeout=30.0, **kwargs)
 
     def requests_post(self, *args, **kwargs):
-        '''
+        """
         Wrapper around requests.post to set all the options uniformly
-        '''
-        kwargs['proxies'] = self.proxies
-        kwargs['verify'] = self.verify
+        """
+        kwargs["proxies"] = self.proxies
+        kwargs["verify"] = self.verify
         if self.user_agent:
-            headers = kwargs.get('headers',{})
-            headers['User-Agent'] = self.user_agent
-            kwargs['headers'] = headers
+            headers = kwargs.get("headers", {})
+            headers["User-Agent"] = self.user_agent
+            kwargs["headers"] = headers
         if self.origin:
-            headers = kwargs.get('headers',{})
-            headers['Origin'] = self.origin
-            kwargs['headers'] = headers
+            headers = kwargs.get("headers", {})
+            headers["Origin"] = self.origin
+            kwargs["headers"] = headers
         return requests.post(*args, timeout=30.0, **kwargs)
 
     def parse_args(self, args):
@@ -1765,28 +2023,34 @@ class Authentication():
             if self.tokendata:
                 return self.tokendata
             if self.refresh_token and not self.access_token:
-                if self.refresh_token == 'file':
-                    with codecs.open(args.tokenfile, 'r', 'utf-8') as infile:
+                if self.refresh_token == "file":
+                    with codecs.open(args.tokenfile, "r", "utf-8") as infile:
                         token_data = json.load(infile)
                 else:
-                    token_data = {'refreshToken': self.refresh_token}
+                    token_data = {"refreshToken": self.refresh_token}
                 if self.scope:
-                    return self.authenticate_with_refresh_native_v2(token_data['refreshToken'], client_secret=self.password)
-                return self.authenticate_with_refresh_native(token_data['refreshToken'], client_secret=self.password)
+                    return self.authenticate_with_refresh_native_v2(
+                        token_data["refreshToken"], client_secret=self.password
+                    )
+                return self.authenticate_with_refresh_native(
+                    token_data["refreshToken"], client_secret=self.password
+                )
             if self.access_token and not self.refresh_token:
                 self.tokendata, _ = self.parse_accesstoken(self.access_token)
                 return self.tokendata
             if self.username and self.password:
                 discovery = self.user_discovery_v1(self.username)
-                if discovery['account_type'] == 'Federated':
+                if discovery["account_type"] == "Federated":
                     # Use the federation flow
-                    return self.authenticate_username_password_federation_native(discovery)
+                    return self.authenticate_username_password_federation_native(
+                        discovery
+                    )
                 # Use native implementation
                 if self.scope:
                     return self.authenticate_username_password_native_v2()
                 return self.authenticate_username_password_native()
             if self.saml_token:
-                if self.saml_token.lower() == 'stdin':
+                if self.saml_token.lower() == "stdin":
                     samltoken = sys.stdin.read()
                 else:
                     samltoken = self.saml_token
@@ -1804,13 +2068,15 @@ class Authentication():
             if args.prt_init:
                 nonce = self.get_srv_challenge_nonce()
                 if nonce:
-                    print(f'Requested nonce from server to use with ROADtoken: {nonce}')
+                    print(f"Requested nonce from server to use with ROADtoken: {nonce}")
                 return False
             if args.prt_cookie:
                 derived_key = self.ensure_binary_derivedkey(args.derived_key)
                 context = self.ensure_binary_context(args.prt_context)
                 sessionkey = self.ensure_binary_sessionkey(args.prt_sessionkey)
-                return self.authenticate_with_prt_cookie(args.prt_cookie, context, derived_key, args.prt_verify, sessionkey)
+                return self.authenticate_with_prt_cookie(
+                    args.prt_cookie, context, derived_key, args.prt_verify, sessionkey
+                )
             if args.prt and args.prt_context and args.derived_key:
                 derived_key = self.ensure_binary_derivedkey(args.derived_key)
                 context = self.ensure_binary_context(args.prt_context)
@@ -1833,21 +2099,26 @@ class Authentication():
             sys.exit(1)
 
         # If we are here, no auth to try
-        print('Not enough information was supplied to authenticate')
+        print("Not enough information was supplied to authenticate")
         return False
 
     def save_tokens(self, args):
         if self.origin:
-            self.tokendata['originheader'] = self.origin
+            self.tokendata["originheader"] = self.origin
         if args.tokens_stdout:
             sys.stdout.write(json.dumps(self.tokendata))
         else:
-            with codecs.open(self.outfile, 'w', 'utf-8') as outfile:
+            with codecs.open(self.outfile, "w", "utf-8") as outfile:
                 json.dump(self.tokendata, outfile)
-            print('Tokens were written to {}'.format(self.outfile))
+            print("Tokens were written to {}".format(self.outfile))
+
 
 def main():
-    parser = argparse.ArgumentParser(add_help=True, description='ROADtools Authentication utility', formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        add_help=True,
+        description="ROADtools Authentication utility",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     auth = Authentication()
     auth.get_sub_argparse(parser)
     if len(sys.argv) < 2:
@@ -1859,5 +2130,6 @@ def main():
         return
     auth.save_tokens(args)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/roadlib/roadtools/roadlib/constants.py
+++ b/roadlib/roadtools/roadlib/constants.py
@@ -10,7 +10,7 @@ WELLKNOWN_RESOURCES = {
     "azrm": "https://management.core.windows.net/",
     "azurerm": "https://management.core.windows.net/",
     "outlook": "https://outlook.office.com/",
-    "sharepoint": "00000003-0000-0ff1-ce00-000000000000"
+    "sharepoint": "00000003-0000-0ff1-ce00-000000000000",
 }
 
 WELLKNOWN_CLIENTS = {
@@ -23,7 +23,9 @@ WELLKNOWN_CLIENTS = {
     "edge": "ecd6b820-32c2-49b6-98a6-444530e5a77a",
     "msbroker": "29d9ed98-a469-4536-ade2-f981bc1d605e",
     "broker": "29d9ed98-a469-4536-ade2-f981bc1d605e",
-    "companyportal": "9ba1a5c7-f17a-4de9-a1f1-6178c8d51223"
+    "companyportal": "9ba1a5c7-f17a-4de9-a1f1-6178c8d51223",
+    "graph": "de8bc8b5-d9f9-48b1-a8ad-b748da725064",
+    "msgraph": "de8bc8b5-d9f9-48b1-a8ad-b748da725064",
 }
 
 WELLKNOWN_USER_AGENTS = {
@@ -43,10 +45,10 @@ WELLKNOWN_USER_AGENTS = {
     "safari": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.1",
     "safari_macos": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.1",
     "safari_ios": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_6_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.",
-    "empty": "No user agent header"
+    "empty": "No user agent header",
 }
 
-DSSO_BODY_KERBEROS = '''<?xml version='1.0' encoding='UTF-8'?>
+DSSO_BODY_KERBEROS = """<?xml version='1.0' encoding='UTF-8'?>
 <s:Envelope
     xmlns:s='http://www.w3.org/2003/05/soap-envelope'
     xmlns:wsse='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd'
@@ -73,9 +75,9 @@ DSSO_BODY_KERBEROS = '''<?xml version='1.0' encoding='UTF-8'?>
         </wst:RequestSecurityToken>
     </s:Body>
 </s:Envelope>
-'''
+"""
 
-DSSO_BODY_USERPASS = '''<?xml version='1.0' encoding='UTF-8'?>
+DSSO_BODY_USERPASS = """<?xml version='1.0' encoding='UTF-8'?>
 <s:Envelope xmlns:s='http://www.w3.org/2003/05/soap-envelope' xmlns:a='http://www.w3.org/2005/08/addressing' xmlns:u='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd'>
   <s:Header>
     <a:Action s:mustUnderstand='1'>http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue</a:Action>
@@ -107,13 +109,17 @@ DSSO_BODY_USERPASS = '''<?xml version='1.0' encoding='UTF-8'?>
     </trust:RequestSecurityToken>
   </s:Body>
 </s:Envelope>
-'''
+"""
 
-SAML_TOKEN_TYPE_V1 = 'urn:oasis:names:tc:SAML:1.0:assertion'
-SAML_TOKEN_TYPE_V2 = 'urn:oasis:names:tc:SAML:2.0:assertion'
-GRANT_TYPE_SAML1_1 = 'urn:ietf:params:oauth:grant-type:saml1_1-bearer'
+SAML_TOKEN_TYPE_V1 = "urn:oasis:names:tc:SAML:1.0:assertion"
+SAML_TOKEN_TYPE_V2 = "urn:oasis:names:tc:SAML:2.0:assertion"
+GRANT_TYPE_SAML1_1 = "urn:ietf:params:oauth:grant-type:saml1_1-bearer"
 GRANT_TYPE_SAML2 = "urn:ietf:params:oauth:grant-type:saml2-bearer"
 
 # http://docs.oasis-open.org/wss-m/wss/v1.1.1/os/wss-SAMLTokenProfile-v1.1.1-os.html#_Toc307397288
-WSS_SAML_TOKEN_PROFILE_V1_1 = "http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV1.1"
-WSS_SAML_TOKEN_PROFILE_V2 = "http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV2.0"
+WSS_SAML_TOKEN_PROFILE_V1_1 = (
+    "http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV1.1"
+)
+WSS_SAML_TOKEN_PROFILE_V2 = (
+    "http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV2.0"
+)

--- a/roadtx/roadtools/roadtx/firstpartyscopes.json
+++ b/roadtx/roadtools/roadtx/firstpartyscopes.json
@@ -22263,6 +22263,19 @@
                 ]
             }
         },
+        "de8bc8b5-d9f9-48b1-a8ad-b748da725064": {
+            "name": "Graph Explorer",
+            "public_client": true,
+            "foci": false,
+            "preferred_interactive_redirurl": "https://developer.microsoft.com/en-us/graph/graph-explorer",
+            "preferred_noninteractive_redirurl": "https://developer.microsoft.com/en-us/graph/graph-explorer",
+            "redirect_uris": [
+                "https://developer.microsoft.com/en-us/graph/graph-explorer"
+            ],
+            "origin": "https://developer.microsoft.com",
+            "default_scope": "https://graph.microsoft.com/.default",
+            "requires_pkce": true
+        },
         "52c2e0b5-c7b6-4d11-a89c-21e42bcec444": {
             "foci": false,
             "name": "Graph Files Manager",

--- a/roadtx/roadtools/roadtx/firstpartyscopes.json
+++ b/roadtx/roadtools/roadtx/firstpartyscopes.json
@@ -22273,7 +22273,7 @@
                 "https://developer.microsoft.com/en-us/graph/graph-explorer"
             ],
             "origin": "https://developer.microsoft.com",
-            "default_scope": "https://graph.microsoft.com/.default",
+            "default_scope": "openid https://graph.microsoft.com/.default offline_access",
             "requires_pkce": true
         },
         "52c2e0b5-c7b6-4d11-a89c-21e42bcec444": {

--- a/roadtx/roadtools/roadtx/main.py
+++ b/roadtx/roadtools/roadtx/main.py
@@ -9,154 +9,401 @@ import time
 from collections import defaultdict
 from urllib.parse import urlparse, parse_qs, quote_plus
 from roadtools.roadlib.auth import Authentication, get_data, AuthenticationException
-from roadtools.roadlib.constants import WELLKNOWN_CLIENTS, WELLKNOWN_RESOURCES, WELLKNOWN_USER_AGENTS
+from roadtools.roadlib.constants import (
+    WELLKNOWN_CLIENTS,
+    WELLKNOWN_RESOURCES,
+    WELLKNOWN_USER_AGENTS,
+)
 from roadtools.roadlib.deviceauth import DeviceAuthentication
 from roadtools.roadtx.selenium import SeleniumAuthentication
-from roadtools.roadtx.utils import find_redirurl_for_client
+from roadtools.roadtx.utils import find_redirurl_for_client, enrich_args_from_firstparty
 from roadtools.roadtx.federation import EncryptedPFX, SAMLSigner, encode_object_guid
 import pyotp
 
-RR_HELP = 'ROADtools Token eXchange by Dirk-jan Mollema (@_dirkjan) / Outsider Security (outsidersecurity.nl)'
+RR_HELP = "ROADtools Token eXchange by Dirk-jan Mollema (@_dirkjan) / Outsider Security (outsidersecurity.nl)"
+
 
 def main():
     # Primary argument parser
-    parser = argparse.ArgumentParser(add_help=True, description=RR_HELP, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('-p', '--proxy', action='store', help="Proxy requests through a proxy (format: proxyip:port). Ignores TLS validation if specified, unless --secure is used.")
-    parser.add_argument('-pt', '--proxy-type', action='store', default="http", help="Proxy type to use. Supported: http / socks4 / socks5. Default: http")
-    parser.add_argument('-s', '--secure', action='store_true', help="Enforce certificate validation even if using a proxy")
+    parser = argparse.ArgumentParser(
+        add_help=True,
+        description=RR_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "-p",
+        "--proxy",
+        action="store",
+        help="Proxy requests through a proxy (format: proxyip:port). Ignores TLS validation if specified, unless --secure is used.",
+    )
+    parser.add_argument(
+        "-pt",
+        "--proxy-type",
+        action="store",
+        default="http",
+        help="Proxy type to use. Supported: http / socks4 / socks5. Default: http",
+    )
+    parser.add_argument(
+        "-s",
+        "--secure",
+        action="store_true",
+        help="Enforce certificate validation even if using a proxy",
+    )
 
     # Add subparsers for modules
-    subparsers = parser.add_subparsers(dest='command')
+    subparsers = parser.add_subparsers(dest="command")
 
     # Construct authentication module options
     auth = Authentication()
-    auth_parser = subparsers.add_parser('gettokens', aliases=['auth','gettoken'], help='Authenticate to Azure AD and get access/refresh tokens. Supports various authentication methods.')
+    auth_parser = subparsers.add_parser(
+        "gettokens",
+        aliases=["auth", "gettoken"],
+        help="Authenticate to Azure AD and get access/refresh tokens. Supports various authentication methods.",
+    )
     auth.get_sub_argparse(auth_parser, for_rr=False)
 
     # Refresh token helper
-    rttsauth_parser = subparsers.add_parser('refreshtokento', help='Use cached refresh token to switch between resources or clients')
-    clienthelptext = 'Client ID (application ID) to use when authenticating. Accepts aliases (list with roadtx listaliases). Read from token file if not supplied'
-    rttsauth_parser.add_argument('-c',
-                                 '--client',
-                                 action='store',
-                                 help=clienthelptext)
-    rttsauth_parser.add_argument('-r',
-                                 '--resource',
-                                 action='store',
-                                 help='Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)',
-                                 default='https://graph.windows.net')
-    rttsauth_parser.add_argument('--refresh-token', action='store', help='Custom refresh token to use instead of taking it from the tokenfile')
-    rttsauth_parser.add_argument('-p', '--password', action='store', metavar='PASSWORD', help='Password secret of the application if not a public app')
-    rttsauth_parser.add_argument('-s',
-                                 '--scope',
-                                 action='store',
-                                 help='Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.')
-    rttsauth_parser.add_argument('-t',
-                                 '--tenant',
-                                 action='store',
-                                 help='Tenant ID or domain to auth to')
-    rttsauth_parser.add_argument('--tokenfile',
-                                 action='store',
-                                 help='File to read and store the tokens from/to (default: .roadtools_auth)',
-                                 default='.roadtools_auth')
-    rttsauth_parser.add_argument('--tokens-stdout',
-                                 action='store_true',
-                                 help='Do not store tokens on disk, pipe to stdout instead')
-    rttsauth_parser.add_argument('-ua', '--user-agent', action='store',
-                                 help='Custom user agent to use. Default: Python requests user agent')
-    rttsauth_parser.add_argument('--cae',
-                                 action='store_true',
-                                 help='Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)')
-    rttsauth_parser.add_argument('--origin',
-                                 action='store',
-                                 help='Origin header to use in refresh token redemption (for single page app flows)')
-    rttsauth_parser.add_argument('--autobroker',
-                                 action='store_true',
-                                 help='Find broker parameters in built-in first party apps automatically (for Nested App Auth)')
-    rttsauth_parser.add_argument('-bc',
-                                 '--broker-client',
-                                 action='store',
-                                 help='Broker client ID (for Nested App Auth)')
-    rttsauth_parser.add_argument('-bru',
-                                 '--broker-redirect-url',
-                                 action='store',
-                                 help='Broker redirect URL (for Nested App Auth)')
+    rttsauth_parser = subparsers.add_parser(
+        "refreshtokento",
+        help="Use cached refresh token to switch between resources or clients",
+    )
+    clienthelptext = "Client ID (application ID) to use when authenticating. Accepts aliases (list with roadtx listaliases). Read from token file if not supplied"
+    rttsauth_parser.add_argument("-c", "--client", action="store", help=clienthelptext)
+    rttsauth_parser.add_argument(
+        "-r",
+        "--resource",
+        action="store",
+        help="Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)",
+        default="https://graph.windows.net",
+    )
+    rttsauth_parser.add_argument(
+        "--refresh-token",
+        action="store",
+        help="Custom refresh token to use instead of taking it from the tokenfile",
+    )
+    rttsauth_parser.add_argument(
+        "-p",
+        "--password",
+        action="store",
+        metavar="PASSWORD",
+        help="Password secret of the application if not a public app",
+    )
+    rttsauth_parser.add_argument(
+        "-s",
+        "--scope",
+        action="store",
+        help="Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.",
+    )
+    rttsauth_parser.add_argument(
+        "-t", "--tenant", action="store", help="Tenant ID or domain to auth to"
+    )
+    rttsauth_parser.add_argument(
+        "--tokenfile",
+        action="store",
+        help="File to read and store the tokens from/to (default: .roadtools_auth)",
+        default=".roadtools_auth",
+    )
+    rttsauth_parser.add_argument(
+        "--tokens-stdout",
+        action="store_true",
+        help="Do not store tokens on disk, pipe to stdout instead",
+    )
+    rttsauth_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. Default: Python requests user agent",
+    )
+    rttsauth_parser.add_argument(
+        "--cae",
+        action="store_true",
+        help="Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)",
+    )
+    rttsauth_parser.add_argument(
+        "--origin",
+        action="store",
+        help="Origin header to use in refresh token redemption (for single page app flows)",
+    )
+    rttsauth_parser.add_argument(
+        "--autobroker",
+        action="store_true",
+        help="Find broker parameters in built-in first party apps automatically (for Nested App Auth)",
+    )
+    rttsauth_parser.add_argument(
+        "-bc",
+        "--broker-client",
+        action="store",
+        help="Broker client ID (for Nested App Auth)",
+    )
+    rttsauth_parser.add_argument(
+        "-bru",
+        "--broker-redirect-url",
+        action="store",
+        help="Broker redirect URL (for Nested App Auth)",
+    )
 
     # Construct device module
-    device_parser = subparsers.add_parser('device', help='Register or join devices to Azure AD')
-    device_parser.add_argument('-a',
-                               '--action',
-                               action='store',
-                               choices=['join','register','delete'],
-                               default='join',
-                               help='Action to perform (default: join)')
-    device_parser.add_argument('-c', '--cert-pem', action='store', metavar='file', help='Certificate file to save device cert to (default: <devicename>.pem)')
-    device_parser.add_argument('-k', '--key-pem', action='store', metavar='file', help='Private key file for certificate (default: <devicename>.key)')
-    device_parser.add_argument('-n', '--name', action='store', help='Device display name (default: DESKTOP-<RANDOM>)')
-    device_parser.add_argument('-d','--domain',action='store',help='Target domain to join to (default: iminyour.cloud)')
-    device_parser.add_argument('--access-token', action='store', help='Access token for device registration service. If not specified, taken from .roadtools_auth')
-    device_parser.add_argument('--device-type', action='store', help='Device OS type (default: Windows)')
-    device_parser.add_argument('--os-version', action='store', help='Device OS version (default: 10.0.19041.928)')
-    device_parser.add_argument('--deviceticket', action='store', help='Device MSA ticket to match with existing device')
-    device_parser.add_argument('-ua', '--user-agent', action='store',
-                               help='Custom request user agent to use. Default: Depends on device type')
+    device_parser = subparsers.add_parser(
+        "device", help="Register or join devices to Azure AD"
+    )
+    device_parser.add_argument(
+        "-a",
+        "--action",
+        action="store",
+        choices=["join", "register", "delete"],
+        default="join",
+        help="Action to perform (default: join)",
+    )
+    device_parser.add_argument(
+        "-c",
+        "--cert-pem",
+        action="store",
+        metavar="file",
+        help="Certificate file to save device cert to (default: <devicename>.pem)",
+    )
+    device_parser.add_argument(
+        "-k",
+        "--key-pem",
+        action="store",
+        metavar="file",
+        help="Private key file for certificate (default: <devicename>.key)",
+    )
+    device_parser.add_argument(
+        "-n",
+        "--name",
+        action="store",
+        help="Device display name (default: DESKTOP-<RANDOM>)",
+    )
+    device_parser.add_argument(
+        "-d",
+        "--domain",
+        action="store",
+        help="Target domain to join to (default: iminyour.cloud)",
+    )
+    device_parser.add_argument(
+        "--access-token",
+        action="store",
+        help="Access token for device registration service. If not specified, taken from .roadtools_auth",
+    )
+    device_parser.add_argument(
+        "--device-type", action="store", help="Device OS type (default: Windows)"
+    )
+    device_parser.add_argument(
+        "--os-version",
+        action="store",
+        help="Device OS version (default: 10.0.19041.928)",
+    )
+    device_parser.add_argument(
+        "--deviceticket",
+        action="store",
+        help="Device MSA ticket to match with existing device",
+    )
+    device_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom request user agent to use. Default: Depends on device type",
+    )
 
     # Construct hybrid device module
-    hdevice_parser = subparsers.add_parser('hybriddevice', help='Join an on-prem device to Azure AD')
-    hdevice_parser.add_argument('-c', '--cert-pem', action='store', metavar='file', help='Certificate file containing on-prem device cert')
-    hdevice_parser.add_argument('-k', '--key-pem', action='store', metavar='file', help='Private key file for device certificate')
-    hdevice_parser.add_argument('--cert-pfx', action='store', metavar='file', help='Device cert and key as PFX file')
-    hdevice_parser.add_argument('--pfx-pass', action='store', metavar='password', help='PFX file password')
-    hdevice_parser.add_argument('--pfx-base64', action='store', metavar='BASE64', help='PFX file as base64 string')
-    hdevice_parser.add_argument('-n', '--name', action='store', help='Device display name (default: DESKTOP-<RANDOM>)')
-    hdevice_parser.add_argument('-d','--domain',action='store',help='Target domain to join to (default: iminyour.cloud)')
-    hdevice_parser.add_argument('--device-type', action='store', help='Device OS type (default: Windows)')
-    hdevice_parser.add_argument('--os-version', action='store', help='Device OS version (default: 10.0.19041.928)')
-    hdevice_parser.add_argument('--sid', action='store', required=True, help='Device SID in AD')
-    hdevice_parser.add_argument('-t', '--tenant', action='store', required=True, help='Tenant ID where device exists')
-    hdevice_parser.add_argument('-ua', '--user-agent', action='store',
-                                help='Custom user agent to use. Default: Python requests user agent')
+    hdevice_parser = subparsers.add_parser(
+        "hybriddevice", help="Join an on-prem device to Azure AD"
+    )
+    hdevice_parser.add_argument(
+        "-c",
+        "--cert-pem",
+        action="store",
+        metavar="file",
+        help="Certificate file containing on-prem device cert",
+    )
+    hdevice_parser.add_argument(
+        "-k",
+        "--key-pem",
+        action="store",
+        metavar="file",
+        help="Private key file for device certificate",
+    )
+    hdevice_parser.add_argument(
+        "--cert-pfx",
+        action="store",
+        metavar="file",
+        help="Device cert and key as PFX file",
+    )
+    hdevice_parser.add_argument(
+        "--pfx-pass", action="store", metavar="password", help="PFX file password"
+    )
+    hdevice_parser.add_argument(
+        "--pfx-base64",
+        action="store",
+        metavar="BASE64",
+        help="PFX file as base64 string",
+    )
+    hdevice_parser.add_argument(
+        "-n",
+        "--name",
+        action="store",
+        help="Device display name (default: DESKTOP-<RANDOM>)",
+    )
+    hdevice_parser.add_argument(
+        "-d",
+        "--domain",
+        action="store",
+        help="Target domain to join to (default: iminyour.cloud)",
+    )
+    hdevice_parser.add_argument(
+        "--device-type", action="store", help="Device OS type (default: Windows)"
+    )
+    hdevice_parser.add_argument(
+        "--os-version",
+        action="store",
+        help="Device OS version (default: 10.0.19041.928)",
+    )
+    hdevice_parser.add_argument(
+        "--sid", action="store", required=True, help="Device SID in AD"
+    )
+    hdevice_parser.add_argument(
+        "-t",
+        "--tenant",
+        action="store",
+        required=True,
+        help="Tenant ID where device exists",
+    )
+    hdevice_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. Default: Python requests user agent",
+    )
 
     # Construct PRT module
-    prt_parser = subparsers.add_parser('prt', help='PRT request/renewal module')
-    prt_parser.add_argument('-a',
-                            '--action',
-                            action='store',
-                            choices=['request', 'renew'],
-                            default='request',
-                            help='Action to perform (default: request)')
-    prt_parser.add_argument('-c', '--cert-pem', action='store', metavar='file', help='Certificate file with device certificate')
-    prt_parser.add_argument('-k', '--key-pem', action='store', metavar='file', help='Private key file for device')
-    prt_parser.add_argument('--cert-pfx', action='store', metavar='file', help='Device cert and key as PFX file')
-    prt_parser.add_argument('--pfx-pass', action='store', metavar='password', help='PFX file password')
-    prt_parser.add_argument('--pfx-base64', action='store', metavar='BASE64', help='PFX file as base64 string')
-    prt_parser.add_argument('-tk', '--transport-key-pem', action='store', metavar='file', help='Private key file containing transport key (if different from device key)')
+    prt_parser = subparsers.add_parser("prt", help="PRT request/renewal module")
+    prt_parser.add_argument(
+        "-a",
+        "--action",
+        action="store",
+        choices=["request", "renew"],
+        default="request",
+        help="Action to perform (default: request)",
+    )
+    prt_parser.add_argument(
+        "-c",
+        "--cert-pem",
+        action="store",
+        metavar="file",
+        help="Certificate file with device certificate",
+    )
+    prt_parser.add_argument(
+        "-k",
+        "--key-pem",
+        action="store",
+        metavar="file",
+        help="Private key file for device",
+    )
+    prt_parser.add_argument(
+        "--cert-pfx",
+        action="store",
+        metavar="file",
+        help="Device cert and key as PFX file",
+    )
+    prt_parser.add_argument(
+        "--pfx-pass", action="store", metavar="password", help="PFX file password"
+    )
+    prt_parser.add_argument(
+        "--pfx-base64",
+        action="store",
+        metavar="BASE64",
+        help="PFX file as base64 string",
+    )
+    prt_parser.add_argument(
+        "-tk",
+        "--transport-key-pem",
+        action="store",
+        metavar="file",
+        help="Private key file containing transport key (if different from device key)",
+    )
 
-    prt_parser.add_argument('-u', '--username', action='store', metavar='USER', help='User to authenticate')
-    prt_parser.add_argument('-p', '--password', action='store', metavar='PASSWORD', help='Password')
-    prt_parser.add_argument('-r', '--refresh-token', action='store', help='Refresh token')
-    prt_parser.add_argument('--saml-token', action='store', help='SAML token for federated auth (use value stdin to read from input)')
+    prt_parser.add_argument(
+        "-u", "--username", action="store", metavar="USER", help="User to authenticate"
+    )
+    prt_parser.add_argument(
+        "-p", "--password", action="store", metavar="PASSWORD", help="Password"
+    )
+    prt_parser.add_argument(
+        "-r", "--refresh-token", action="store", help="Refresh token"
+    )
+    prt_parser.add_argument(
+        "--saml-token",
+        action="store",
+        help="SAML token for federated auth (use value stdin to read from input)",
+    )
 
+    prt_parser.add_argument(
+        "-f",
+        "--prt-file",
+        default="roadtx.prt",
+        action="store",
+        metavar="FILE",
+        help="PRT storage file (to save or load in case of renewal)",
+    )
+    prt_parser.add_argument(
+        "--prt",
+        action="store",
+        metavar="PRT",
+        help="Primary Refresh Token (for renewal)",
+    )
+    prt_parser.add_argument(
+        "-s",
+        "--prt-sessionkey",
+        action="store",
+        help="Primary Refresh Token session key (as hex key)",
+    )
 
+    prt_parser.add_argument(
+        "-v3",
+        "--prt-protocol-v3",
+        action="store_true",
+        help="Use PRT protocol version 3.0",
+    )
 
-    prt_parser.add_argument('-f', '--prt-file', default="roadtx.prt", action='store', metavar='FILE', help='PRT storage file (to save or load in case of renewal)')
-    prt_parser.add_argument('--prt', action='store', metavar='PRT', help='Primary Refresh Token (for renewal)')
-    prt_parser.add_argument('-s', '--prt-sessionkey', action='store', help='Primary Refresh Token session key (as hex key)')
+    prt_parser.add_argument(
+        "-hk", "--hello-key", action="store", help="Windows Hello PEM file"
+    )
+    prt_parser.add_argument(
+        "-ha",
+        "--hello-assertion",
+        action="store",
+        help="Windows Hello assertion as JWT",
+    )
 
-    prt_parser.add_argument('-v3', '--prt-protocol-v3', action='store_true', help='Use PRT protocol version 3.0')
-
-    prt_parser.add_argument('-hk', '--hello-key', action='store', help='Windows Hello PEM file')
-    prt_parser.add_argument('-ha', '--hello-assertion', action='store', help='Windows Hello assertion as JWT')
-
-    prt_parser.add_argument('-ua', '--user-agent', action='store',
-                            help='Custom user agent to use. Default: Python requests user agent')
+    prt_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. Default: Python requests user agent",
+    )
 
     # Construct winhello module
-    winhello_parser = subparsers.add_parser('winhello', help='Register Windows Hello key')
-    winhello_parser.add_argument('-k', '--key-pem', action='store', metavar='file', help='Private key file for key storage (default: winhello.key)')
-    winhello_parser.add_argument('--access-token', action='store', help='Access token for device registration service. If not specified, taken from .roadtools_auth')
-    winhello_parser.add_argument('-ua', '--user-agent', action='store',
-                                 help='Custom user agent to use. Default: Dsreg/10.0 (Windows 10.0.19044.1826)')
+    winhello_parser = subparsers.add_parser(
+        "winhello", help="Register Windows Hello key"
+    )
+    winhello_parser.add_argument(
+        "-k",
+        "--key-pem",
+        action="store",
+        metavar="file",
+        help="Private key file for key storage (default: winhello.key)",
+    )
+    winhello_parser.add_argument(
+        "--access-token",
+        action="store",
+        help="Access token for device registration service. If not specified, taken from .roadtools_auth",
+    )
+    winhello_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. Default: Dsreg/10.0 (Windows 10.0.19044.1826)",
+    )
 
     # Construct winhello key generation module - included for reference
     # winhello_parser = subparsers.add_parser('genhellokey', help='Generate Windows Hello key')
@@ -164,804 +411,1637 @@ def main():
     # winhello_parser.add_argument('-d', '--device-id', action='store', help='Device ID to use for key object')
 
     # Construct PRT authmodule
-    prtauth_parser = subparsers.add_parser('prtauth', help='Authenticate using a PRT (emulates WAM token broker)')
-    helptext = 'Client ID to use when authenticating.'
-    prtauth_parser.add_argument('-c',
-                                '--client',
-                                action='store',
-                                help=helptext,
-                                default='1b730954-1685-4b74-9bfd-dac224a7b894')
-    prtauth_parser.add_argument('-r',
-                                '--resource',
-                                action='store',
-                                help='Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)',
-                                default='https://graph.windows.net')
-    prtauth_parser.add_argument('-ru', '--redirect-url', action='store', metavar='URL',
-                                 help='Custom redirect URL used when authenticating (default: ms-appx-web://Microsoft.AAD.BrokerPlugin/<clientid>)')
-    prtauth_parser.add_argument('-f', '--prt-file', default="roadtx.prt", action='store', metavar='FILE', help='PRT storage file (default: roadtx.prt)')
-    prtauth_parser.add_argument('--prt',
-                                action='store',
-                                help='Primary Refresh Token')
-    prtauth_parser.add_argument('--prt-sessionkey',
-                                action='store',
-                                help='Primary Refresh Token session key (as hex key)')
-    prtauth_parser.add_argument('--tokenfile',
-                                action='store',
-                                help='File to store the credentials (default: .roadtools_auth)',
-                                default='.roadtools_auth')
-    prtauth_parser.add_argument('--tokens-stdout',
-                                action='store_true',
-                                help='Do not store tokens on disk, pipe to stdout instead')
-    prtauth_parser.add_argument('-ua', '--user-agent', action='store',
-                                help='Custom user agent to use. Default: Python requests user agent')
-    prtauth_parser.add_argument('-t',
-                                '--tenant',
-                                action='store',
-                                help='Tenant ID or domain to auth to')
-    prtauth_parser.add_argument('--cae',
-                                action='store_true',
-                                help='Request Continuous Access Evaluation tokens')
+    prtauth_parser = subparsers.add_parser(
+        "prtauth", help="Authenticate using a PRT (emulates WAM token broker)"
+    )
+    helptext = "Client ID to use when authenticating."
+    prtauth_parser.add_argument(
+        "-c",
+        "--client",
+        action="store",
+        help=helptext,
+        default="1b730954-1685-4b74-9bfd-dac224a7b894",
+    )
+    prtauth_parser.add_argument(
+        "-r",
+        "--resource",
+        action="store",
+        help="Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)",
+        default="https://graph.windows.net",
+    )
+    prtauth_parser.add_argument(
+        "-ru",
+        "--redirect-url",
+        action="store",
+        metavar="URL",
+        help="Custom redirect URL used when authenticating (default: ms-appx-web://Microsoft.AAD.BrokerPlugin/<clientid>)",
+    )
+    prtauth_parser.add_argument(
+        "-f",
+        "--prt-file",
+        default="roadtx.prt",
+        action="store",
+        metavar="FILE",
+        help="PRT storage file (default: roadtx.prt)",
+    )
+    prtauth_parser.add_argument("--prt", action="store", help="Primary Refresh Token")
+    prtauth_parser.add_argument(
+        "--prt-sessionkey",
+        action="store",
+        help="Primary Refresh Token session key (as hex key)",
+    )
+    prtauth_parser.add_argument(
+        "--tokenfile",
+        action="store",
+        help="File to store the credentials (default: .roadtools_auth)",
+        default=".roadtools_auth",
+    )
+    prtauth_parser.add_argument(
+        "--tokens-stdout",
+        action="store_true",
+        help="Do not store tokens on disk, pipe to stdout instead",
+    )
+    prtauth_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. Default: Python requests user agent",
+    )
+    prtauth_parser.add_argument(
+        "-t", "--tenant", action="store", help="Tenant ID or domain to auth to"
+    )
+    prtauth_parser.add_argument(
+        "--cae", action="store_true", help="Request Continuous Access Evaluation tokens"
+    )
 
-    prtauth_parser.add_argument('-s',
-                                '--scope',
-                                action='store',
-                                help='Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.')
-    prtauth_parser.add_argument('-v3', '--prt-protocol-v3', action='store_true', help='Use PRT protocol version v3')
-    prtauth_parser.add_argument('-v4', '--prt-protocol-v4', action='store_true', help='Use PRT protocol version v4')
-    prtauth_parser.add_argument('--cert-pem', action='store', metavar='file', help='Certificate file with device certificate (applies to PRTv4 only)')
-    prtauth_parser.add_argument('-k', '--key-pem', action='store', metavar='file', help='Private key file for device (applies to PRTv4 only)')
-    prtauth_parser.add_argument('--cert-pfx', action='store', metavar='file', help='Device cert and key as PFX file (applies to PRTv4 only)')
-    prtauth_parser.add_argument('--pfx-pass', action='store', metavar='password', help='PFX file password (applies to PRTv4 only)')
-    prtauth_parser.add_argument('--pfx-base64', action='store', metavar='BASE64', help='PFX file as base64 string (applies to PRTv4 only)')
+    prtauth_parser.add_argument(
+        "-s",
+        "--scope",
+        action="store",
+        help="Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.",
+    )
+    prtauth_parser.add_argument(
+        "-v3",
+        "--prt-protocol-v3",
+        action="store_true",
+        help="Use PRT protocol version v3",
+    )
+    prtauth_parser.add_argument(
+        "-v4",
+        "--prt-protocol-v4",
+        action="store_true",
+        help="Use PRT protocol version v4",
+    )
+    prtauth_parser.add_argument(
+        "--cert-pem",
+        action="store",
+        metavar="file",
+        help="Certificate file with device certificate (applies to PRTv4 only)",
+    )
+    prtauth_parser.add_argument(
+        "-k",
+        "--key-pem",
+        action="store",
+        metavar="file",
+        help="Private key file for device (applies to PRTv4 only)",
+    )
+    prtauth_parser.add_argument(
+        "--cert-pfx",
+        action="store",
+        metavar="file",
+        help="Device cert and key as PFX file (applies to PRTv4 only)",
+    )
+    prtauth_parser.add_argument(
+        "--pfx-pass",
+        action="store",
+        metavar="password",
+        help="PFX file password (applies to PRTv4 only)",
+    )
+    prtauth_parser.add_argument(
+        "--pfx-base64",
+        action="store",
+        metavar="BASE64",
+        help="PFX file as base64 string (applies to PRTv4 only)",
+    )
 
     # Application auth
-    appauth_parser = subparsers.add_parser('appauth', help='Authenticate as an application')
-    appauth_parser.add_argument('-c',
-                                '--client',
-                                action='store',
-                                help='Client ID (application ID) to use when authenticating.',
-                                required=True)
-    appauth_parser.add_argument('-p',
-                                '--password',
-                                action='store',
-                                help="Client secret or password credential for the application, if not using certificates")
-    appauth_parser.add_argument('-r',
-                                '--resource',
-                                action='store',
-                                help='Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)',
-                                default='https://graph.windows.net')
-    appauth_parser.add_argument('-s',
-                                '--scope',
-                                action='store',
-                                help='Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.')
-    appauth_parser.add_argument('-t',
-                                '--tenant',
-                                action='store',
-                                help='Tenant ID or domain to auth to',
-                                required=True)
-    appauth_parser.add_argument('--cert-pem', action='store', metavar='file', help='Certificate file with Application certificate')
-    appauth_parser.add_argument('--key-pem', action='store', metavar='file', help='Private key file for Application')
-    appauth_parser.add_argument('--cert-pfx', action='store', metavar='file', help='Application cert and key as PFX file')
-    appauth_parser.add_argument('--pfx-pass', action='store', metavar='password', help='PFX file password')
-    appauth_parser.add_argument('--pfx-base64', action='store', metavar='BASE64', help='PFX file as base64 string')
-    appauth_parser.add_argument('--assertion', action='store', metavar='JWT', help='Signed JWT assertion for cert based auth')
-    appauth_parser.add_argument('--cae',
-                                action='store_true',
-                                help='Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)')
-    appauth_parser.add_argument('-ua', '--user-agent', action='store',
-                                help='Custom user agent to use. Default: Python requests user agent')
-    appauth_parser.add_argument('--tokenfile',
-                                action='store',
-                                help='File to store the credentials (default: .roadtools_auth)',
-                                default='.roadtools_auth')
-    appauth_parser.add_argument('--tokens-stdout',
-                                action='store_true',
-                                help='Do not store tokens on disk, pipe to stdout instead')
+    appauth_parser = subparsers.add_parser(
+        "appauth", help="Authenticate as an application"
+    )
+    appauth_parser.add_argument(
+        "-c",
+        "--client",
+        action="store",
+        help="Client ID (application ID) to use when authenticating.",
+        required=True,
+    )
+    appauth_parser.add_argument(
+        "-p",
+        "--password",
+        action="store",
+        help="Client secret or password credential for the application, if not using certificates",
+    )
+    appauth_parser.add_argument(
+        "-r",
+        "--resource",
+        action="store",
+        help="Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)",
+        default="https://graph.windows.net",
+    )
+    appauth_parser.add_argument(
+        "-s",
+        "--scope",
+        action="store",
+        help="Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.",
+    )
+    appauth_parser.add_argument(
+        "-t",
+        "--tenant",
+        action="store",
+        help="Tenant ID or domain to auth to",
+        required=True,
+    )
+    appauth_parser.add_argument(
+        "--cert-pem",
+        action="store",
+        metavar="file",
+        help="Certificate file with Application certificate",
+    )
+    appauth_parser.add_argument(
+        "--key-pem",
+        action="store",
+        metavar="file",
+        help="Private key file for Application",
+    )
+    appauth_parser.add_argument(
+        "--cert-pfx",
+        action="store",
+        metavar="file",
+        help="Application cert and key as PFX file",
+    )
+    appauth_parser.add_argument(
+        "--pfx-pass", action="store", metavar="password", help="PFX file password"
+    )
+    appauth_parser.add_argument(
+        "--pfx-base64",
+        action="store",
+        metavar="BASE64",
+        help="PFX file as base64 string",
+    )
+    appauth_parser.add_argument(
+        "--assertion",
+        action="store",
+        metavar="JWT",
+        help="Signed JWT assertion for cert based auth",
+    )
+    appauth_parser.add_argument(
+        "--cae",
+        action="store_true",
+        help="Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)",
+    )
+    appauth_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. Default: Python requests user agent",
+    )
+    appauth_parser.add_argument(
+        "--tokenfile",
+        action="store",
+        help="File to store the credentials (default: .roadtools_auth)",
+        default=".roadtools_auth",
+    )
+    appauth_parser.add_argument(
+        "--tokens-stdout",
+        action="store_true",
+        help="Do not store tokens on disk, pipe to stdout instead",
+    )
 
     # Application auth - on behalf of
-    oboauth_parser = subparsers.add_parser('appauthobo', help='Authenticate with the on-behalf-of flow')
-    oboauth_parser.add_argument('-c',
-                                '--client',
-                                action='store',
-                                help='Client ID (application ID) to use when authenticating.',
-                                required=True)
-    oboauth_parser.add_argument('-p',
-                                '--password',
-                                action='store',
-                                help="Client secret or password credential for the application, if not using certificates")
-    oboauth_parser.add_argument('-r',
-                                '--resource',
-                                action='store',
-                                help='Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)',
-                                default='https://graph.windows.net')
-    oboauth_parser.add_argument('-s',
-                                '--scope',
-                                action='store',
-                                help='Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.')
-    oboauth_parser.add_argument('-t',
-                                '--tenant',
-                                action='store',
-                                help='Tenant ID or domain to auth to',
-                                required=True)
-    oboauth_parser.add_argument('--cert-pem', action='store', metavar='file', help='Certificate file with Application certificate')
-    oboauth_parser.add_argument('--key-pem', action='store', metavar='file', help='Private key file for Application')
-    oboauth_parser.add_argument('--cert-pfx', action='store', metavar='file', help='Application cert and key as PFX file')
-    oboauth_parser.add_argument('--pfx-pass', action='store', metavar='password', help='PFX file password')
-    oboauth_parser.add_argument('--pfx-base64', action='store', metavar='BASE64', help='PFX file as base64 string')
-    oboauth_parser.add_argument('--cae',
-                                action='store_true',
-                                help='Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)')
-    oboauth_parser.add_argument('-ua', '--user-agent', action='store',
-                                help='Custom user agent to use. Default: Python requests user agent')
-    oboauth_parser.add_argument('--tokenfile',
-                                action='store',
-                                help='File to store the credentials (default: .roadtools_auth)',
-                                default='.roadtools_auth')
-    oboauth_parser.add_argument('--tokens-stdout',
-                                action='store_true',
-                                help='Do not store tokens on disk, pipe to stdout instead')
-    oboauth_parser.add_argument('token',
-                                action='store',
-                                help='Token to middleware application that has the client ID as audience')
+    oboauth_parser = subparsers.add_parser(
+        "appauthobo", help="Authenticate with the on-behalf-of flow"
+    )
+    oboauth_parser.add_argument(
+        "-c",
+        "--client",
+        action="store",
+        help="Client ID (application ID) to use when authenticating.",
+        required=True,
+    )
+    oboauth_parser.add_argument(
+        "-p",
+        "--password",
+        action="store",
+        help="Client secret or password credential for the application, if not using certificates",
+    )
+    oboauth_parser.add_argument(
+        "-r",
+        "--resource",
+        action="store",
+        help="Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)",
+        default="https://graph.windows.net",
+    )
+    oboauth_parser.add_argument(
+        "-s",
+        "--scope",
+        action="store",
+        help="Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.",
+    )
+    oboauth_parser.add_argument(
+        "-t",
+        "--tenant",
+        action="store",
+        help="Tenant ID or domain to auth to",
+        required=True,
+    )
+    oboauth_parser.add_argument(
+        "--cert-pem",
+        action="store",
+        metavar="file",
+        help="Certificate file with Application certificate",
+    )
+    oboauth_parser.add_argument(
+        "--key-pem",
+        action="store",
+        metavar="file",
+        help="Private key file for Application",
+    )
+    oboauth_parser.add_argument(
+        "--cert-pfx",
+        action="store",
+        metavar="file",
+        help="Application cert and key as PFX file",
+    )
+    oboauth_parser.add_argument(
+        "--pfx-pass", action="store", metavar="password", help="PFX file password"
+    )
+    oboauth_parser.add_argument(
+        "--pfx-base64",
+        action="store",
+        metavar="BASE64",
+        help="PFX file as base64 string",
+    )
+    oboauth_parser.add_argument(
+        "--cae",
+        action="store_true",
+        help="Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)",
+    )
+    oboauth_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. Default: Python requests user agent",
+    )
+    oboauth_parser.add_argument(
+        "--tokenfile",
+        action="store",
+        help="File to store the credentials (default: .roadtools_auth)",
+        default=".roadtools_auth",
+    )
+    oboauth_parser.add_argument(
+        "--tokens-stdout",
+        action="store_true",
+        help="Do not store tokens on disk, pipe to stdout instead",
+    )
+    oboauth_parser.add_argument(
+        "token",
+        action="store",
+        help="Token to middleware application that has the client ID as audience",
+    )
 
     # Federated application auth
-    fedauth_parser = subparsers.add_parser('federatedappauth', help='Authenticate as an application with federated credentials')
-    fedauth_parser.add_argument('-c',
-                                '--client',
-                                action='store',
-                                help='Client ID (application ID) to use when authenticating.',
-                                required=True)
-    fedauth_parser.add_argument('-r',
-                                '--resource',
-                                action='store',
-                                help='Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)',
-                                default='https://graph.windows.net')
-    fedauth_parser.add_argument('-s',
-                                '--scope',
-                                action='store',
-                                help='Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.')
-    fedauth_parser.add_argument('-t',
-                                '--tenant',
-                                action='store',
-                                help='Tenant ID or domain to auth to',
-                                required=True)
-    fedauth_parser.add_argument('--subject',
-                                action='store',
-                                help='Authentication subject as configured in federated credential',
-                                required=True)
-    fedauth_parser.add_argument('--audience',
-                                action='store',
-                                help='Audience of the federated assertion (default: api://AzureADTokenExchange)',
-                                default='api://AzureADTokenExchange')
-    fedauth_parser.add_argument('-i',
-                                '--issuer',
-                                action='store',
-                                help='Issuer as configured in federated credential',
-                                required=True)
-    fedauth_parser.add_argument('-k',
-                                '--kid',
-                                action='store',
-                                help='Key ID configured (default: SHA1 thumbprint of certificate, if provided)')
-    fedauth_parser.add_argument('--cert-pem', action='store', metavar='file', help='Certificate file with IdP certificate')
-    fedauth_parser.add_argument('--key-pem', action='store', metavar='file', help='Private key file for IdP')
-    fedauth_parser.add_argument('--cert-pfx', action='store', metavar='file', help='IdP cert and key as PFX file')
-    fedauth_parser.add_argument('--pfx-pass', action='store', metavar='password', help='PFX file password')
-    fedauth_parser.add_argument('--pfx-base64', action='store', metavar='BASE64', help='PFX file as base64 string')
-    fedauth_parser.add_argument('--cae',
-                                action='store_true',
-                                help='Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)')
-    fedauth_parser.add_argument('-ua', '--user-agent', action='store',
-                                help='Custom user agent to use. Default: Python requests user agent')
-    fedauth_parser.add_argument('--tokenfile',
-                                action='store',
-                                help='File to store the credentials (default: .roadtools_auth)',
-                                default='.roadtools_auth')
-    fedauth_parser.add_argument('--tokens-stdout',
-                                action='store_true',
-                                help='Do not store tokens on disk, pipe to stdout instead')
+    fedauth_parser = subparsers.add_parser(
+        "federatedappauth",
+        help="Authenticate as an application with federated credentials",
+    )
+    fedauth_parser.add_argument(
+        "-c",
+        "--client",
+        action="store",
+        help="Client ID (application ID) to use when authenticating.",
+        required=True,
+    )
+    fedauth_parser.add_argument(
+        "-r",
+        "--resource",
+        action="store",
+        help="Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)",
+        default="https://graph.windows.net",
+    )
+    fedauth_parser.add_argument(
+        "-s",
+        "--scope",
+        action="store",
+        help="Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.",
+    )
+    fedauth_parser.add_argument(
+        "-t",
+        "--tenant",
+        action="store",
+        help="Tenant ID or domain to auth to",
+        required=True,
+    )
+    fedauth_parser.add_argument(
+        "--subject",
+        action="store",
+        help="Authentication subject as configured in federated credential",
+        required=True,
+    )
+    fedauth_parser.add_argument(
+        "--audience",
+        action="store",
+        help="Audience of the federated assertion (default: api://AzureADTokenExchange)",
+        default="api://AzureADTokenExchange",
+    )
+    fedauth_parser.add_argument(
+        "-i",
+        "--issuer",
+        action="store",
+        help="Issuer as configured in federated credential",
+        required=True,
+    )
+    fedauth_parser.add_argument(
+        "-k",
+        "--kid",
+        action="store",
+        help="Key ID configured (default: SHA1 thumbprint of certificate, if provided)",
+    )
+    fedauth_parser.add_argument(
+        "--cert-pem",
+        action="store",
+        metavar="file",
+        help="Certificate file with IdP certificate",
+    )
+    fedauth_parser.add_argument(
+        "--key-pem", action="store", metavar="file", help="Private key file for IdP"
+    )
+    fedauth_parser.add_argument(
+        "--cert-pfx",
+        action="store",
+        metavar="file",
+        help="IdP cert and key as PFX file",
+    )
+    fedauth_parser.add_argument(
+        "--pfx-pass", action="store", metavar="password", help="PFX file password"
+    )
+    fedauth_parser.add_argument(
+        "--pfx-base64",
+        action="store",
+        metavar="BASE64",
+        help="PFX file as base64 string",
+    )
+    fedauth_parser.add_argument(
+        "--cae",
+        action="store_true",
+        help="Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)",
+    )
+    fedauth_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. Default: Python requests user agent",
+    )
+    fedauth_parser.add_argument(
+        "--tokenfile",
+        action="store",
+        help="File to store the credentials (default: .roadtools_auth)",
+        default=".roadtools_auth",
+    )
+    fedauth_parser.add_argument(
+        "--tokens-stdout",
+        action="store_true",
+        help="Do not store tokens on disk, pipe to stdout instead",
+    )
 
     # Construct device token module
-    devauth_parser = subparsers.add_parser('deviceauth', aliases=('getdevicetokens', 'getdevicetoken'), help='Request device tokens with device cert')
-    devauth_parser.add_argument('-c', '--cert-pem', action='store', metavar='file', help='Certificate file with device certificate')
-    devauth_parser.add_argument('-k', '--key-pem', action='store', metavar='file', help='Private key file for device')
-    devauth_parser.add_argument('--cert-pfx', action='store', metavar='file', help='Device cert and key as PFX file')
-    devauth_parser.add_argument('--pfx-pass', action='store', metavar='password', help='PFX file password')
-    devauth_parser.add_argument('--pfx-base64', action='store', metavar='BASE64', help='PFX file as base64 string')
-    helptext = 'Client ID to use when authenticating.'
-    devauth_parser.add_argument('--client',
-                                action='store',
-                                help=helptext,
-                                default='1b730954-1685-4b74-9bfd-dac224a7b894')
-    devauth_parser.add_argument('-r',
-                                '--resource',
-                                action='store',
-                                help='Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)',
-                                default='https://graph.windows.net')
-    devauth_parser.add_argument('-ru', '--redirect-url', action='store', metavar='URL',
-                                 help='Custom redirect URL used when authenticating (default: ms-appx-web://Microsoft.AAD.BrokerPlugin/<clientid>)')
-    devauth_parser.add_argument('--tokenfile',
-                                action='store',
-                                help='File to store the credentials (default: .roadtools_auth)',
-                                default='.roadtools_auth')
-    devauth_parser.add_argument('--tokens-stdout',
-                                action='store_true',
-                                help='Do not store tokens on disk, pipe to stdout instead')
-    devauth_parser.add_argument('-ua', '--user-agent', action='store',
-                                help='Custom user agent to use. Default: Python requests user agent')
-    devauth_parser.add_argument('-t',
-                                '--tenant',
-                                required=True,
-                                action='store',
-                                help='Tenant ID or domain to auth to')
+    devauth_parser = subparsers.add_parser(
+        "deviceauth",
+        aliases=("getdevicetokens", "getdevicetoken"),
+        help="Request device tokens with device cert",
+    )
+    devauth_parser.add_argument(
+        "-c",
+        "--cert-pem",
+        action="store",
+        metavar="file",
+        help="Certificate file with device certificate",
+    )
+    devauth_parser.add_argument(
+        "-k",
+        "--key-pem",
+        action="store",
+        metavar="file",
+        help="Private key file for device",
+    )
+    devauth_parser.add_argument(
+        "--cert-pfx",
+        action="store",
+        metavar="file",
+        help="Device cert and key as PFX file",
+    )
+    devauth_parser.add_argument(
+        "--pfx-pass", action="store", metavar="password", help="PFX file password"
+    )
+    devauth_parser.add_argument(
+        "--pfx-base64",
+        action="store",
+        metavar="BASE64",
+        help="PFX file as base64 string",
+    )
+    helptext = "Client ID to use when authenticating."
+    devauth_parser.add_argument(
+        "--client",
+        action="store",
+        help=helptext,
+        default="1b730954-1685-4b74-9bfd-dac224a7b894",
+    )
+    devauth_parser.add_argument(
+        "-r",
+        "--resource",
+        action="store",
+        help="Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)",
+        default="https://graph.windows.net",
+    )
+    devauth_parser.add_argument(
+        "-ru",
+        "--redirect-url",
+        action="store",
+        metavar="URL",
+        help="Custom redirect URL used when authenticating (default: ms-appx-web://Microsoft.AAD.BrokerPlugin/<clientid>)",
+    )
+    devauth_parser.add_argument(
+        "--tokenfile",
+        action="store",
+        help="File to store the credentials (default: .roadtools_auth)",
+        default=".roadtools_auth",
+    )
+    devauth_parser.add_argument(
+        "--tokens-stdout",
+        action="store_true",
+        help="Do not store tokens on disk, pipe to stdout instead",
+    )
+    devauth_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. Default: Python requests user agent",
+    )
+    devauth_parser.add_argument(
+        "-t",
+        "--tenant",
+        required=True,
+        action="store",
+        help="Tenant ID or domain to auth to",
+    )
 
     # Code grant flow auth
-    codeauth_parser = subparsers.add_parser('codeauth', help='Code grant flow - exchange code for auth tokens')
-    clienthelptext = 'Client ID (application ID) to use when authenticating. Accepts aliases (list with roadtx listaliases)'
-    codeauth_parser.add_argument('-c',
-                                 '--client',
-                                 action='store',
-                                 help=clienthelptext,
-                                 default='1b730954-1685-4b74-9bfd-dac224a7b894')
-    codeauth_parser.add_argument('-p', '--password', action='store', metavar='PASSWORD', help='Password secret of the application if not a public app')
-    codeauth_parser.add_argument('-r',
-                                 '--resource',
-                                 action='store',
-                                 help='Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)',
-                                 default='https://graph.windows.net')
-    codeauth_parser.add_argument('-s',
-                                 '--scope',
-                                 action='store',
-                                 help='Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.')
-    codeauth_parser.add_argument('-ru', '--redirect-url', action='store', metavar='URL',
-                                 help='Redirect URL used when authenticating (default: https://login.microsoftonline.com/common/oauth2/nativeclient)',
-                                 default="https://login.microsoftonline.com/common/oauth2/nativeclient")
-    codeauth_parser.add_argument('-t',
-                                 '--tenant',
-                                 action='store',
-                                 help='Tenant ID or domain to auth to')
-    codeauth_parser.add_argument('--tokenfile',
-                                 action='store',
-                                 help='File to store the credentials (default: .roadtools_auth)',
-                                 default='.roadtools_auth')
-    codeauth_parser.add_argument('--tokens-stdout',
-                                 action='store_true',
-                                 help='Do not store tokens on disk, pipe to stdout instead')
-    codeauth_parser.add_argument('--cae',
-                                 action='store_true',
-                                 help='Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)')
-    codeauth_parser.add_argument('code',
-                                 action='store',
-                                 help="Code to auth with that you got from Azure AD")
-    codeauth_parser.add_argument('-ua', '--user-agent', action='store',
-                                 help='Custom user agent to use. Default: Python requests user agent')
-    codeauth_parser.add_argument('--pkce-secret',
-                                 action='store',
-                                 help='PKCE secret to redeem the code')
-    codeauth_parser.add_argument('--origin',
-                                 action='store',
-                                 help='Origin header to use in code redemption (for single page app flows)')
+    codeauth_parser = subparsers.add_parser(
+        "codeauth", help="Code grant flow - exchange code for auth tokens"
+    )
+    clienthelptext = "Client ID (application ID) to use when authenticating. Accepts aliases (list with roadtx listaliases)"
+    codeauth_parser.add_argument(
+        "-c",
+        "--client",
+        action="store",
+        help=clienthelptext,
+        default="1b730954-1685-4b74-9bfd-dac224a7b894",
+    )
+    codeauth_parser.add_argument(
+        "-p",
+        "--password",
+        action="store",
+        metavar="PASSWORD",
+        help="Password secret of the application if not a public app",
+    )
+    codeauth_parser.add_argument(
+        "-r",
+        "--resource",
+        action="store",
+        help="Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)",
+        default="https://graph.windows.net",
+    )
+    codeauth_parser.add_argument(
+        "-s",
+        "--scope",
+        action="store",
+        help="Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.",
+    )
+    codeauth_parser.add_argument(
+        "-ru",
+        "--redirect-url",
+        action="store",
+        metavar="URL",
+        help="Redirect URL used when authenticating (default: https://login.microsoftonline.com/common/oauth2/nativeclient)",
+        default="https://login.microsoftonline.com/common/oauth2/nativeclient",
+    )
+    codeauth_parser.add_argument(
+        "-t", "--tenant", action="store", help="Tenant ID or domain to auth to"
+    )
+    codeauth_parser.add_argument(
+        "--tokenfile",
+        action="store",
+        help="File to store the credentials (default: .roadtools_auth)",
+        default=".roadtools_auth",
+    )
+    codeauth_parser.add_argument(
+        "--tokens-stdout",
+        action="store_true",
+        help="Do not store tokens on disk, pipe to stdout instead",
+    )
+    codeauth_parser.add_argument(
+        "--cae",
+        action="store_true",
+        help="Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)",
+    )
+    codeauth_parser.add_argument(
+        "code", action="store", help="Code to auth with that you got from Azure AD"
+    )
+    codeauth_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. Default: Python requests user agent",
+    )
+    codeauth_parser.add_argument(
+        "--pkce-secret", action="store", help="PKCE secret to redeem the code"
+    )
+    codeauth_parser.add_argument(
+        "--origin",
+        action="store",
+        help="Origin header to use in code redemption (for single page app flows)",
+    )
 
     # Bulk enrollment token
-    bulkenrollment_parser = subparsers.add_parser('bulkenrollmenttoken', help='Request / use bulk enrollment tokens')
-    bulkenrollment_parser.add_argument('--access-token', action='store', help='Access token for the device registration service. If not specified, taken from .roadtools_auth or file specified with --tokenfile')
-    bulkenrollment_parser.add_argument('-a',
-                                       '--action',
-                                       action='store',
-                                       choices=['request', 'use'],
-                                       default='request',
-                                       help='Action to perform (default: request)')
-    bulkenrollment_parser.add_argument('--bulktokenfile',
-                                       action='store',
-                                       default='.bulktoken',
-                                       help='File to save / load bulk enrollment token from (default: .bulktoken)')
-    bulkenrollment_parser.add_argument('--tokenfile',
-                                       action='store',
-                                       default='.roadtools_auth',
-                                       help='File to save / load the access token for device registration service to / from')
-    bulkenrollment_parser.add_argument('--tokens-stdout',
-                                       action='store_true',
-                                       help='Do not store tokens on disk, pipe to stdout instead')
+    bulkenrollment_parser = subparsers.add_parser(
+        "bulkenrollmenttoken", help="Request / use bulk enrollment tokens"
+    )
+    bulkenrollment_parser.add_argument(
+        "--access-token",
+        action="store",
+        help="Access token for the device registration service. If not specified, taken from .roadtools_auth or file specified with --tokenfile",
+    )
+    bulkenrollment_parser.add_argument(
+        "-a",
+        "--action",
+        action="store",
+        choices=["request", "use"],
+        default="request",
+        help="Action to perform (default: request)",
+    )
+    bulkenrollment_parser.add_argument(
+        "--bulktokenfile",
+        action="store",
+        default=".bulktoken",
+        help="File to save / load bulk enrollment token from (default: .bulktoken)",
+    )
+    bulkenrollment_parser.add_argument(
+        "--tokenfile",
+        action="store",
+        default=".roadtools_auth",
+        help="File to save / load the access token for device registration service to / from",
+    )
+    bulkenrollment_parser.add_argument(
+        "--tokens-stdout",
+        action="store_true",
+        help="Do not store tokens on disk, pipe to stdout instead",
+    )
 
     # Desktop SSO auth
-    desktopsso_parser = subparsers.add_parser('desktopsso', help='Desktop SSO authentication - either with plaintext creds or Kerberos auth')
-    clienthelptext = 'Client ID (application ID) to use when authenticating. Accepts aliases (list with roadtx listaliases)'
-    desktopsso_parser.add_argument('-c',
-                                   '--client',
-                                   action='store',
-                                   help=clienthelptext,
-                                   default='1b730954-1685-4b74-9bfd-dac224a7b894')
-    desktopsso_parser.add_argument('-u', '--username', action='store', metavar='USER', help='User to authenticate')
-    desktopsso_parser.add_argument('-p', '--password', action='store', metavar='PASSWORD', help='Password of the user')
-    desktopsso_parser.add_argument('--krbtoken',
-                                   action='store',
-                                   help='Kerberos auth data from krbsso.py')
-    desktopsso_parser.add_argument('-r',
-                                   '--resource',
-                                   action='store',
-                                   help='Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)',
-                                   default='https://graph.windows.net')
-    desktopsso_parser.add_argument('-t',
-                                   '--tenant',
-                                   action='store',
-                                   required=True,
-                                   help='Tenant ID or domain to auth to')
-    desktopsso_parser.add_argument('--tokenfile',
-                                   action='store',
-                                   help='File to store the credentials (default: .roadtools_auth)',
-                                   default='.roadtools_auth')
-    desktopsso_parser.add_argument('--tokens-stdout',
-                                   action='store_true',
-                                   help='Do not store tokens on disk, pipe to stdout instead')
-    desktopsso_parser.add_argument('-ua', '--user-agent', action='store',
-                                   help='Custom user agent to use. By default the user agent from FireFox is used without modification')
-
+    desktopsso_parser = subparsers.add_parser(
+        "desktopsso",
+        help="Desktop SSO authentication - either with plaintext creds or Kerberos auth",
+    )
+    clienthelptext = "Client ID (application ID) to use when authenticating. Accepts aliases (list with roadtx listaliases)"
+    desktopsso_parser.add_argument(
+        "-c",
+        "--client",
+        action="store",
+        help=clienthelptext,
+        default="1b730954-1685-4b74-9bfd-dac224a7b894",
+    )
+    desktopsso_parser.add_argument(
+        "-u", "--username", action="store", metavar="USER", help="User to authenticate"
+    )
+    desktopsso_parser.add_argument(
+        "-p",
+        "--password",
+        action="store",
+        metavar="PASSWORD",
+        help="Password of the user",
+    )
+    desktopsso_parser.add_argument(
+        "--krbtoken", action="store", help="Kerberos auth data from krbsso.py"
+    )
+    desktopsso_parser.add_argument(
+        "-r",
+        "--resource",
+        action="store",
+        help="Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)",
+        default="https://graph.windows.net",
+    )
+    desktopsso_parser.add_argument(
+        "-t",
+        "--tenant",
+        action="store",
+        required=True,
+        help="Tenant ID or domain to auth to",
+    )
+    desktopsso_parser.add_argument(
+        "--tokenfile",
+        action="store",
+        help="File to store the credentials (default: .roadtools_auth)",
+        default=".roadtools_auth",
+    )
+    desktopsso_parser.add_argument(
+        "--tokens-stdout",
+        action="store_true",
+        help="Do not store tokens on disk, pipe to stdout instead",
+    )
+    desktopsso_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. By default the user agent from FireFox is used without modification",
+    )
 
     # List aliases
-    subparsers.add_parser('listaliases', help='List aliases that can be used as client ID or resource URL')
+    subparsers.add_parser(
+        "listaliases", help="List aliases that can be used as client ID or resource URL"
+    )
 
     # Decrypt utilities
-    decrypt_parser = subparsers.add_parser('decrypt', help='Decrypt data using session key or transport key')
-    decrypt_parser.add_argument('-f', '--prt-file', default="roadtx.prt", action='store', metavar='FILE', help='PRT storage file (to load the session key)')
-    decrypt_parser.add_argument('-k', '--key-pem', action='store', metavar='file', help='Private key file containing transport key')
-    decrypt_parser.add_argument('--cert-pfx', action='store', metavar='file', help='Device cert and key as PFX file')
-    decrypt_parser.add_argument('--pfx-pass', action='store', metavar='password', help='PFX file password')
-    decrypt_parser.add_argument('--pfx-base64', action='store', metavar='BASE64', help='PFX file as base64 string')
-    decrypt_parser.add_argument('-s', '--prt-sessionkey', action='store', help='Primary Refresh Token session key (as hex key)')
-    decrypt_parser.add_argument('-v', '--verbose', action='store_true', help='Show extra information')
-    decrypt_parser.add_argument('data', action='store', metavar='FILE', help='Data to decrypt (as JWE token)')
+    decrypt_parser = subparsers.add_parser(
+        "decrypt", help="Decrypt data using session key or transport key"
+    )
+    decrypt_parser.add_argument(
+        "-f",
+        "--prt-file",
+        default="roadtx.prt",
+        action="store",
+        metavar="FILE",
+        help="PRT storage file (to load the session key)",
+    )
+    decrypt_parser.add_argument(
+        "-k",
+        "--key-pem",
+        action="store",
+        metavar="file",
+        help="Private key file containing transport key",
+    )
+    decrypt_parser.add_argument(
+        "--cert-pfx",
+        action="store",
+        metavar="file",
+        help="Device cert and key as PFX file",
+    )
+    decrypt_parser.add_argument(
+        "--pfx-pass", action="store", metavar="password", help="PFX file password"
+    )
+    decrypt_parser.add_argument(
+        "--pfx-base64",
+        action="store",
+        metavar="BASE64",
+        help="PFX file as base64 string",
+    )
+    decrypt_parser.add_argument(
+        "-s",
+        "--prt-sessionkey",
+        action="store",
+        help="Primary Refresh Token session key (as hex key)",
+    )
+    decrypt_parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Show extra information"
+    )
+    decrypt_parser.add_argument(
+        "data", action="store", metavar="FILE", help="Data to decrypt (as JWE token)"
+    )
 
     # Describe token
-    describe_parser = subparsers.add_parser('describe', help='Decode and describe an access token')
-    describe_parser.add_argument('-t', '--token', default=None, action='store', metavar='TOKEN', help='Token data to describe. Defaults to reading from stdin')
-    describe_parser.add_argument('-f', '--tokenfile', action='store', help='File to read the token from (default: .roadtools_auth)', default='.roadtools_auth')
-    describe_parser.add_argument('-v', '--verbose', action='store_true', help='Show extra information')
+    describe_parser = subparsers.add_parser(
+        "describe", help="Decode and describe an access token"
+    )
+    describe_parser.add_argument(
+        "-t",
+        "--token",
+        default=None,
+        action="store",
+        metavar="TOKEN",
+        help="Token data to describe. Defaults to reading from stdin",
+    )
+    describe_parser.add_argument(
+        "-f",
+        "--tokenfile",
+        action="store",
+        help="File to read the token from (default: .roadtools_auth)",
+        default=".roadtools_auth",
+    )
+    describe_parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Show extra information"
+    )
 
     # Find scope
-    getscope_parser = subparsers.add_parser('getscope', aliases=['findscope'], help='Find first-party apps with the right pre-approved scope')
-    getscope_parser.add_argument('-s', '--scope', default=None, action='store', required=False, metavar='SCOPE', help='Desired scope (API URL + scope on that API, for example https://graph.microsoft.com/files.read).')
-    getscope_parser.add_argument('-a', '--all', action='store_true', help='List all scopes instead')
-    getscope_parser.add_argument('--foci', action='store_true', help='Only list FOCI clients')
-    getscope_parser.add_argument('--all-clients', action='store_true', help='List all clients instead of public clients only (may require advanced auth flow to use)')
-    getscope_parser.add_argument('--csv', action='store_true', help='Output in CSV format')
+    getscope_parser = subparsers.add_parser(
+        "getscope",
+        aliases=["findscope"],
+        help="Find first-party apps with the right pre-approved scope",
+    )
+    getscope_parser.add_argument(
+        "-s",
+        "--scope",
+        default=None,
+        action="store",
+        required=False,
+        metavar="SCOPE",
+        help="Desired scope (API URL + scope on that API, for example https://graph.microsoft.com/files.read).",
+    )
+    getscope_parser.add_argument(
+        "-a", "--all", action="store_true", help="List all scopes instead"
+    )
+    getscope_parser.add_argument(
+        "--foci", action="store_true", help="Only list FOCI clients"
+    )
+    getscope_parser.add_argument(
+        "--all-clients",
+        action="store_true",
+        help="List all clients instead of public clients only (may require advanced auth flow to use)",
+    )
+    getscope_parser.add_argument(
+        "--csv", action="store_true", help="Output in CSV format"
+    )
 
     # Get OTP
-    otpparser = subparsers.add_parser('getotp', help='Get OTP code from seed, either supplied or from KeePass file')
-    otpparser.add_argument('-u', '--username', action='store', help='User to query from KeePass file')
-    otpparser.add_argument('-s', '--otpseed', action='store', help='OTP secret seed')
-    otpparser.add_argument('-kp', '--keepass', action='store', metavar='KPFILE', default='roadtx.kdbx', help='KeePass file (default: roadtx.kdbx)')
-    otpparser.add_argument('-kpp', '--keepass-password', action='store', metavar='KPPASS', help='KeePass file password. Can also be provided via KPPASS environment variable.')
-
+    otpparser = subparsers.add_parser(
+        "getotp", help="Get OTP code from seed, either supplied or from KeePass file"
+    )
+    otpparser.add_argument(
+        "-u", "--username", action="store", help="User to query from KeePass file"
+    )
+    otpparser.add_argument("-s", "--otpseed", action="store", help="OTP secret seed")
+    otpparser.add_argument(
+        "-kp",
+        "--keepass",
+        action="store",
+        metavar="KPFILE",
+        default="roadtx.kdbx",
+        help="KeePass file (default: roadtx.kdbx)",
+    )
+    otpparser.add_argument(
+        "-kpp",
+        "--keepass-password",
+        action="store",
+        metavar="KPPASS",
+        help="KeePass file password. Can also be provided via KPPASS environment variable.",
+    )
 
     # Interactive auth using Selenium
-    urlhelp = 'Url to initiate browsing. Will be constructed from below parameters if not supplied.'
-    intauth_parser = subparsers.add_parser('interactiveauth', help='Interactive authentication in Selenium browser window, optional autofill')
-    intauth_parser.add_argument('-u', '--username', action='store', metavar='USER', help='User to authenticate')
-    intauth_parser.add_argument('-p', '--password', action='store', metavar='PASSWORD', help='Password of the user')
-    intauth_parser.add_argument('--krbtoken',
-                                action='store',
-                                help='Kerberos auth data from krbsso.py')
-    intauth_parser.add_argument('--estscookie',
-                                action='store',
-                                help='ESTSAUTHPERSISTENT cookie from browser')
-    intauth_parser.add_argument('-url', '--url', '--auth-url', action='store', metavar='URL', help=urlhelp)
-    intauth_parser.add_argument('-c',
-                                '--client',
-                                action='store',
-                                help=clienthelptext,
-                                default='1b730954-1685-4b74-9bfd-dac224a7b894')
-    intauth_parser.add_argument('-r',
-                                '--resource',
-                                action='store',
-                                help='Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)',
-                                default='https://graph.windows.net')
-    intauth_parser.add_argument('-s',
-                                '--scope',
-                                action='store',
-                                help='Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.')
-    intauth_parser.add_argument('-ru', '--redirect-url', action='store', metavar='URL',
-                                help='Redirect URL used when authenticating (default: chosen automatically based on well-known URLs for first party clients)')
-    intauth_parser.add_argument('-ua', '--user-agent', action='store',
-                                help='Custom user agent to use. By default the user agent from FireFox is used without modification')
-    intauth_parser.add_argument('-t',
-                                '--tenant',
-                                action='store',
-                                help='Tenant ID or domain to auth to')
-    intauth_parser.add_argument('--tokenfile',
-                                action='store',
-                                help='File to store the credentials (default: .roadtools_auth)',
-                                default='.roadtools_auth')
-    intauth_parser.add_argument('--tokens-stdout',
-                                action='store_true',
-                                help='Do not store tokens on disk, pipe to stdout instead')
-    intauth_parser.add_argument('-d', '--driver-path',
-                                action='store',
-                                help='Path to geckodriver file on disk (download from: https://github.com/mozilla/geckodriver/releases)')
-    intauth_parser.add_argument('-k', '--keep-open',
-                                action='store_true',
-                                help='Do not close the browser window after timeout. Useful if you want to browse online apps with the obtained credentials')
-    intauth_parser.add_argument('--capture-code',
-                                action='store_true',
-                                help='Do not attempt to redeem any authentication code but print it instead')
-    intauth_parser.add_argument('--federated',
-                                action='store_true',
-                                help='Fill in password on Federation server login page (assumes AD FS)')
-    intauth_parser.add_argument('--cae',
-                                action='store_true',
-                                help='Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)')
-    intauth_parser.add_argument('--force-mfa',
-                                action='store_true',
-                                help='Force MFA during authentication')
-    intauth_parser.add_argument('--pkce',
-                                action='store_true',
-                                help='Use PKCE during authentication')
-    intauth_parser.add_argument('--origin',
-                                action='store',
-                                help='Origin header to use in code redemption (for single page app flows)')
-    intauth_parser.add_argument('--otpseed',
-                                action='store',
-                                help='TOTP seed to calculate MFA code when prompted')
+    urlhelp = "Url to initiate browsing. Will be constructed from below parameters if not supplied."
+    intauth_parser = subparsers.add_parser(
+        "interactiveauth",
+        help="Interactive authentication in Selenium browser window, optional autofill",
+    )
+    intauth_parser.add_argument(
+        "-u", "--username", action="store", metavar="USER", help="User to authenticate"
+    )
+    intauth_parser.add_argument(
+        "-p",
+        "--password",
+        action="store",
+        metavar="PASSWORD",
+        help="Password of the user",
+    )
+    intauth_parser.add_argument(
+        "--krbtoken", action="store", help="Kerberos auth data from krbsso.py"
+    )
+    intauth_parser.add_argument(
+        "--estscookie", action="store", help="ESTSAUTHPERSISTENT cookie from browser"
+    )
+    intauth_parser.add_argument(
+        "-url", "--url", "--auth-url", action="store", metavar="URL", help=urlhelp
+    )
+    intauth_parser.add_argument(
+        "-c",
+        "--client",
+        action="store",
+        help=clienthelptext,
+        default="1b730954-1685-4b74-9bfd-dac224a7b894",
+    )
+    intauth_parser.add_argument(
+        "-r",
+        "--resource",
+        action="store",
+        help="Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)",
+        default="https://graph.windows.net",
+    )
+    intauth_parser.add_argument(
+        "-s",
+        "--scope",
+        action="store",
+        help="Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.",
+    )
+    intauth_parser.add_argument(
+        "-ru",
+        "--redirect-url",
+        action="store",
+        metavar="URL",
+        help="Redirect URL used when authenticating (default: chosen automatically based on well-known URLs for first party clients)",
+    )
+    intauth_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. By default the user agent from FireFox is used without modification",
+    )
+    intauth_parser.add_argument(
+        "-t", "--tenant", action="store", help="Tenant ID or domain to auth to"
+    )
+    intauth_parser.add_argument(
+        "--tokenfile",
+        action="store",
+        help="File to store the credentials (default: .roadtools_auth)",
+        default=".roadtools_auth",
+    )
+    intauth_parser.add_argument(
+        "--tokens-stdout",
+        action="store_true",
+        help="Do not store tokens on disk, pipe to stdout instead",
+    )
+    intauth_parser.add_argument(
+        "-d",
+        "--driver-path",
+        action="store",
+        help="Path to geckodriver file on disk (download from: https://github.com/mozilla/geckodriver/releases)",
+    )
+    intauth_parser.add_argument(
+        "-k",
+        "--keep-open",
+        action="store_true",
+        help="Do not close the browser window after timeout. Useful if you want to browse online apps with the obtained credentials",
+    )
+    intauth_parser.add_argument(
+        "--capture-code",
+        action="store_true",
+        help="Do not attempt to redeem any authentication code but print it instead",
+    )
+    intauth_parser.add_argument(
+        "--federated",
+        action="store_true",
+        help="Fill in password on Federation server login page (assumes AD FS)",
+    )
+    intauth_parser.add_argument(
+        "--cae",
+        action="store_true",
+        help="Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)",
+    )
+    intauth_parser.add_argument(
+        "--force-mfa", action="store_true", help="Force MFA during authentication"
+    )
+    intauth_parser.add_argument(
+        "--pkce", action="store_true", help="Use PKCE during authentication"
+    )
+    intauth_parser.add_argument(
+        "--origin",
+        action="store",
+        help="Origin header to use in code redemption (for single page app flows)",
+    )
+    intauth_parser.add_argument(
+        "--otpseed",
+        action="store",
+        help="TOTP seed to calculate MFA code when prompted",
+    )
 
     # Interactive auth using Selenium - creds from keepass
-    kdbauth_parser = subparsers.add_parser('keepassauth', help='Selenium based authentication with credentials from a KeePass database')
-    kdbauth_parser.add_argument('-u', '--username', action='store', help='User to authenticate as (must exist as username in KeePass)')
-    kdbauth_parser.add_argument('-kp', '--keepass', action='store', metavar='KPFILE', default='roadtx.kdbx', help='KeePass file (default: roadtx.kdbx)')
-    kdbauth_parser.add_argument('-kpp', '--keepass-password', action='store', metavar='KPPASS', help='KeePass file password. Can also be provided via KPPASS environment variable.')
-    kdbauth_parser.add_argument('-url', '--url', '--auth-url', action='store', metavar='URL', help=urlhelp)
-    kdbauth_parser.add_argument('-c',
-                                '--client',
-                                action='store',
-                                help=clienthelptext,
-                                default='1b730954-1685-4b74-9bfd-dac224a7b894')
-    kdbauth_parser.add_argument('-r',
-                                '--resource',
-                                action='store',
-                                help='Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)',
-                                default='https://graph.windows.net')
-    kdbauth_parser.add_argument('-s',
-                                '--scope',
-                                action='store',
-                                help='Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.')
-    kdbauth_parser.add_argument('-ru', '--redirect-url', action='store', metavar='URL',
-                                help='Redirect URL used when authenticating (default: chosen automatically based on well-known URLs for first party clients)')
-    kdbauth_parser.add_argument('-ua', '--user-agent', action='store',
-                                help='Custom user agent to use. By default the user agent from FireFox is used without modification')
-    kdbauth_parser.add_argument('-t',
-                                '--tenant',
-                                action='store',
-                                help='Tenant ID or domain to auth to')
-    kdbauth_parser.add_argument('--tokenfile',
-                                action='store',
-                                help='File to store the credentials (default: .roadtools_auth)',
-                                default='.roadtools_auth')
-    kdbauth_parser.add_argument('--tokens-stdout',
-                                action='store_true',
-                                help='Do not store tokens on disk, pipe to stdout instead')
-    kdbauth_parser.add_argument('-d', '--driver-path',
-                                action='store',
-                                help='Path to geckodriver file on disk (download from: https://github.com/mozilla/geckodriver/releases)')
-    kdbauth_parser.add_argument('-k', '--keep-open',
-                                action='store_true',
-                                help='Do not close the browser window after timeout. Useful if you want to browse online apps with the obtained credentials')
-    kdbauth_parser.add_argument('--capture-code',
-                                action='store_true',
-                                help='Do not attempt to redeem any authentication code but print it instead')
-    kdbauth_parser.add_argument('--federated',
-                                action='store_true',
-                                help='Fill in password on Federation server login page (assumes AD FS)')
-    kdbauth_parser.add_argument('--device-code',
-                                action='store',
-                                help='Authenticate with the given device code')
-    kdbauth_parser.add_argument('--cae',
-                                action='store_true',
-                                help='Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)')
-    kdbauth_parser.add_argument('--force-mfa',
-                                action='store_true',
-                                help='Force MFA during authentication')
-    kdbauth_parser.add_argument('--pkce',
-                                action='store_true',
-                                help='Use PKCE during authentication')
-    kdbauth_parser.add_argument('--origin',
-                                action='store',
-                                help='Origin header to use in code redemption (for single page app flows)')
+    kdbauth_parser = subparsers.add_parser(
+        "keepassauth",
+        help="Selenium based authentication with credentials from a KeePass database",
+    )
+    kdbauth_parser.add_argument(
+        "-u",
+        "--username",
+        action="store",
+        help="User to authenticate as (must exist as username in KeePass)",
+    )
+    kdbauth_parser.add_argument(
+        "-kp",
+        "--keepass",
+        action="store",
+        metavar="KPFILE",
+        default="roadtx.kdbx",
+        help="KeePass file (default: roadtx.kdbx)",
+    )
+    kdbauth_parser.add_argument(
+        "-kpp",
+        "--keepass-password",
+        action="store",
+        metavar="KPPASS",
+        help="KeePass file password. Can also be provided via KPPASS environment variable.",
+    )
+    kdbauth_parser.add_argument(
+        "-url", "--url", "--auth-url", action="store", metavar="URL", help=urlhelp
+    )
+    kdbauth_parser.add_argument(
+        "-c",
+        "--client",
+        action="store",
+        help=clienthelptext,
+        default="1b730954-1685-4b74-9bfd-dac224a7b894",
+    )
+    kdbauth_parser.add_argument(
+        "-r",
+        "--resource",
+        action="store",
+        help="Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)",
+        default="https://graph.windows.net",
+    )
+    kdbauth_parser.add_argument(
+        "-s",
+        "--scope",
+        action="store",
+        help="Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.",
+    )
+    kdbauth_parser.add_argument(
+        "-ru",
+        "--redirect-url",
+        action="store",
+        metavar="URL",
+        help="Redirect URL used when authenticating (default: chosen automatically based on well-known URLs for first party clients)",
+    )
+    kdbauth_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. By default the user agent from FireFox is used without modification",
+    )
+    kdbauth_parser.add_argument(
+        "-t", "--tenant", action="store", help="Tenant ID or domain to auth to"
+    )
+    kdbauth_parser.add_argument(
+        "--tokenfile",
+        action="store",
+        help="File to store the credentials (default: .roadtools_auth)",
+        default=".roadtools_auth",
+    )
+    kdbauth_parser.add_argument(
+        "--tokens-stdout",
+        action="store_true",
+        help="Do not store tokens on disk, pipe to stdout instead",
+    )
+    kdbauth_parser.add_argument(
+        "-d",
+        "--driver-path",
+        action="store",
+        help="Path to geckodriver file on disk (download from: https://github.com/mozilla/geckodriver/releases)",
+    )
+    kdbauth_parser.add_argument(
+        "-k",
+        "--keep-open",
+        action="store_true",
+        help="Do not close the browser window after timeout. Useful if you want to browse online apps with the obtained credentials",
+    )
+    kdbauth_parser.add_argument(
+        "--capture-code",
+        action="store_true",
+        help="Do not attempt to redeem any authentication code but print it instead",
+    )
+    kdbauth_parser.add_argument(
+        "--federated",
+        action="store_true",
+        help="Fill in password on Federation server login page (assumes AD FS)",
+    )
+    kdbauth_parser.add_argument(
+        "--device-code", action="store", help="Authenticate with the given device code"
+    )
+    kdbauth_parser.add_argument(
+        "--cae",
+        action="store_true",
+        help="Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)",
+    )
+    kdbauth_parser.add_argument(
+        "--force-mfa", action="store_true", help="Force MFA during authentication"
+    )
+    kdbauth_parser.add_argument(
+        "--pkce", action="store_true", help="Use PKCE during authentication"
+    )
+    kdbauth_parser.add_argument(
+        "--origin",
+        action="store",
+        help="Origin header to use in code redemption (for single page app flows)",
+    )
 
     # Interactive auth using Selenium - inject PRT
-    browserprtauth_parser = subparsers.add_parser('browserprtauth', help='Selenium based auth with automatic PRT usage. Emulates Edge browser with PRT')
-    browserprtauth_parser.add_argument('-url', '--url', '--auth-url', action='store', metavar='URL', help=urlhelp)
-    browserprtauth_parser.add_argument('-c',
-                                       '--client',
-                                       action='store',
-                                       help=helptext,
-                                       default='1b730954-1685-4b74-9bfd-dac224a7b894')
-    browserprtauth_parser.add_argument('-r',
-                                       '--resource',
-                                       action='store',
-                                       help='Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)',
-                                       default='https://graph.windows.net')
-    browserprtauth_parser.add_argument('-s',
-                                       '--scope',
-                                       action='store',
-                                       help='Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.')
-    browserprtauth_parser.add_argument('-ru', '--redirect-url', action='store', metavar='URL',
-                                       help='Redirect URL used when authenticating (default: chosen automatically based on well-known URLs for first party clients)')
-    browserprtauth_parser.add_argument('-ua', '--user-agent', action='store',
-                                       help='Custom user agent to use. Default: Chrome on Windows user agent')
-    browserprtauth_parser.add_argument('-t',
-                                       '--tenant',
-                                       action='store',
-                                       help='Tenant ID or domain to auth to')
-    browserprtauth_parser.add_argument('-f', '--prt-file', default="roadtx.prt", action='store', metavar='FILE', help='PRT storage file (default: roadtx.prt)')
-    browserprtauth_parser.add_argument('--prt',
-                                       action='store',
-                                       help='Primary Refresh Token')
-    browserprtauth_parser.add_argument('--prt-sessionkey',
-                                       action='store',
-                                       help='Primary Refresh Token session key (as hex key)')
-    browserprtauth_parser.add_argument('--prt-cookie',
-                                       action='store',
-                                       help='Primary Refresh Token cookie from ROADtoken (JWT)')
-    browserprtauth_parser.add_argument('--tokenfile',
-                                       action='store',
-                                       help='File to store the credentials (default: .roadtools_auth)',
-                                       default='.roadtools_auth')
-    browserprtauth_parser.add_argument('--tokens-stdout',
-                                       action='store_true',
-                                       help='Do not store tokens on disk, pipe to stdout instead')
-    browserprtauth_parser.add_argument('-d', '--driver-path',
-                                       action='store',
-                                       help='Path to geckodriver file on disk (download from: https://github.com/mozilla/geckodriver/releases)')
-    browserprtauth_parser.add_argument('-k', '--keep-open',
-                                       action='store_true',
-                                       help='Do not close the browser window after timeout. Useful if you want to browse online apps with the obtained credentials')
-    browserprtauth_parser.add_argument('--capture-code',
-                                       action='store_true',
-                                       help='Do not attempt to redeem any authentication code but print it instead')
-    browserprtauth_parser.add_argument('--cae',
-                                       action='store_true',
-                                       help='Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)')
-    browserprtauth_parser.add_argument('--force-mfa',
-                                       action='store_true',
-                                       help='Force MFA during authentication')
-    browserprtauth_parser.add_argument('--pkce',
-                                       action='store_true',
-                                       help='Use PKCE during authentication')
-    browserprtauth_parser.add_argument('--origin',
-                                       action='store',
-                                       help='Origin header to use in code redemption (for single page app flows)')
+    browserprtauth_parser = subparsers.add_parser(
+        "browserprtauth",
+        help="Selenium based auth with automatic PRT usage. Emulates Edge browser with PRT",
+    )
+    browserprtauth_parser.add_argument(
+        "-url", "--url", "--auth-url", action="store", metavar="URL", help=urlhelp
+    )
+    browserprtauth_parser.add_argument(
+        "-c",
+        "--client",
+        action="store",
+        help=helptext,
+        default="1b730954-1685-4b74-9bfd-dac224a7b894",
+    )
+    browserprtauth_parser.add_argument(
+        "-r",
+        "--resource",
+        action="store",
+        help="Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)",
+        default="https://graph.windows.net",
+    )
+    browserprtauth_parser.add_argument(
+        "-s",
+        "--scope",
+        action="store",
+        help="Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.",
+    )
+    browserprtauth_parser.add_argument(
+        "-ru",
+        "--redirect-url",
+        action="store",
+        metavar="URL",
+        help="Redirect URL used when authenticating (default: chosen automatically based on well-known URLs for first party clients)",
+    )
+    browserprtauth_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. Default: Chrome on Windows user agent",
+    )
+    browserprtauth_parser.add_argument(
+        "-t", "--tenant", action="store", help="Tenant ID or domain to auth to"
+    )
+    browserprtauth_parser.add_argument(
+        "-f",
+        "--prt-file",
+        default="roadtx.prt",
+        action="store",
+        metavar="FILE",
+        help="PRT storage file (default: roadtx.prt)",
+    )
+    browserprtauth_parser.add_argument(
+        "--prt", action="store", help="Primary Refresh Token"
+    )
+    browserprtauth_parser.add_argument(
+        "--prt-sessionkey",
+        action="store",
+        help="Primary Refresh Token session key (as hex key)",
+    )
+    browserprtauth_parser.add_argument(
+        "--prt-cookie",
+        action="store",
+        help="Primary Refresh Token cookie from ROADtoken (JWT)",
+    )
+    browserprtauth_parser.add_argument(
+        "--tokenfile",
+        action="store",
+        help="File to store the credentials (default: .roadtools_auth)",
+        default=".roadtools_auth",
+    )
+    browserprtauth_parser.add_argument(
+        "--tokens-stdout",
+        action="store_true",
+        help="Do not store tokens on disk, pipe to stdout instead",
+    )
+    browserprtauth_parser.add_argument(
+        "-d",
+        "--driver-path",
+        action="store",
+        help="Path to geckodriver file on disk (download from: https://github.com/mozilla/geckodriver/releases)",
+    )
+    browserprtauth_parser.add_argument(
+        "-k",
+        "--keep-open",
+        action="store_true",
+        help="Do not close the browser window after timeout. Useful if you want to browse online apps with the obtained credentials",
+    )
+    browserprtauth_parser.add_argument(
+        "--capture-code",
+        action="store_true",
+        help="Do not attempt to redeem any authentication code but print it instead",
+    )
+    browserprtauth_parser.add_argument(
+        "--cae",
+        action="store_true",
+        help="Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)",
+    )
+    browserprtauth_parser.add_argument(
+        "--force-mfa", action="store_true", help="Force MFA during authentication"
+    )
+    browserprtauth_parser.add_argument(
+        "--pkce", action="store_true", help="Use PKCE during authentication"
+    )
+    browserprtauth_parser.add_argument(
+        "--origin",
+        action="store",
+        help="Origin header to use in code redemption (for single page app flows)",
+    )
 
     # Interactive auth using Selenium - inject PRT to other user
-    injauth_parser = subparsers.add_parser('browserprtinject', help='Selenium based auth with automatic PRT injection. Can be used with other users to add device state to session')
-    injauth_parser.add_argument('-u', '--username', action='store', metavar='USER', help='User to authenticate (optional, otherwise you have to specify it by hand)')
-    injauth_parser.add_argument('-p', '--password', action='store', metavar='PASSWORD', help='Password of the user (can be left out if using PRT, or KeePass creds)')
-    injauth_parser.add_argument('-kp', '--keepass', action='store', metavar='KPFILE', default='roadtx.kdbx', help='KeePass file (default: roadtx.kdbx)')
-    injauth_parser.add_argument('-kpp', '--keepass-password', action='store', metavar='KPPASS', help='KeePass file password. Can also be provided via KPPASS environment variable.')
-    injauth_parser.add_argument('-url', '--url', '--auth-url', action='store', metavar='URL', help=urlhelp)
-    injauth_parser.add_argument('-c',
-                                '--client',
-                                action='store',
-                                help=clienthelptext,
-                                default='1b730954-1685-4b74-9bfd-dac224a7b894')
-    injauth_parser.add_argument('-r',
-                                '--resource',
-                                action='store',
-                                help='Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)',
-                                default='https://graph.windows.net')
-    injauth_parser.add_argument('-s',
-                                '--scope',
-                                action='store',
-                                help='Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.')
-    injauth_parser.add_argument('-ru', '--redirect-url', action='store', metavar='URL',
-                                help='Redirect URL used when authenticating (default: chosen automatically based on well-known URLs for first party clients)')
-    injauth_parser.add_argument('-ua', '--user-agent', action='store',
-                                help='Custom user agent to use. Default: Chrome on Windows user agent')
-    injauth_parser.add_argument('-t',
-                                '--tenant',
-                                action='store',
-                                help='Tenant ID or domain to auth to')
-    injauth_parser.add_argument('-d', '--driver-path',
-                                action='store',
-                                help='Path to geckodriver file on disk (download from: https://github.com/mozilla/geckodriver/releases)')
-    injauth_parser.add_argument('-k', '--keep-open',
-                                action='store_true',
-                                help='Do not close the browser window after timeout. Useful if you want to browse online apps with the obtained credentials')
-    injauth_parser.add_argument('-f', '--prt-file', default="roadtx.prt", action='store', metavar='FILE', help='PRT storage file (default: roadtx.prt)')
-    injauth_parser.add_argument('--prt',
-                                action='store',
-                                help='Primary Refresh Token')
-    injauth_parser.add_argument('--prt-sessionkey',
-                                action='store',
-                                help='Primary Refresh Token session key (as hex key)')
-    injauth_parser.add_argument('--prt-cookie',
-                                action='store',
-                                help='Primary Refresh Token cookie from ROADtoken (JWT)')
-    injauth_parser.add_argument('--tokenfile',
-                                action='store',
-                                help='File to store the credentials (default: .roadtools_auth)',
-                                default='.roadtools_auth')
-    injauth_parser.add_argument('--tokens-stdout',
-                                action='store_true',
-                                help='Do not store tokens on disk, pipe to stdout instead')
-    injauth_parser.add_argument('--cae',
-                                action='store_true',
-                                help='Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)')
-    injauth_parser.add_argument('--force-mfa',
-                                action='store_true',
-                                help='Force MFA during authentication')
-    injauth_parser.add_argument('--pkce',
-                                action='store_true',
-                                help='Use PKCE during authentication')
-    injauth_parser.add_argument('--origin',
-                                action='store',
-                                help='Origin header to use in code redemption (for single page app flows)')
-    injauth_parser.add_argument('--otpseed',
-                                action='store',
-                                help='TOTP seed to calculate MFA code when prompted')
+    injauth_parser = subparsers.add_parser(
+        "browserprtinject",
+        help="Selenium based auth with automatic PRT injection. Can be used with other users to add device state to session",
+    )
+    injauth_parser.add_argument(
+        "-u",
+        "--username",
+        action="store",
+        metavar="USER",
+        help="User to authenticate (optional, otherwise you have to specify it by hand)",
+    )
+    injauth_parser.add_argument(
+        "-p",
+        "--password",
+        action="store",
+        metavar="PASSWORD",
+        help="Password of the user (can be left out if using PRT, or KeePass creds)",
+    )
+    injauth_parser.add_argument(
+        "-kp",
+        "--keepass",
+        action="store",
+        metavar="KPFILE",
+        default="roadtx.kdbx",
+        help="KeePass file (default: roadtx.kdbx)",
+    )
+    injauth_parser.add_argument(
+        "-kpp",
+        "--keepass-password",
+        action="store",
+        metavar="KPPASS",
+        help="KeePass file password. Can also be provided via KPPASS environment variable.",
+    )
+    injauth_parser.add_argument(
+        "-url", "--url", "--auth-url", action="store", metavar="URL", help=urlhelp
+    )
+    injauth_parser.add_argument(
+        "-c",
+        "--client",
+        action="store",
+        help=clienthelptext,
+        default="1b730954-1685-4b74-9bfd-dac224a7b894",
+    )
+    injauth_parser.add_argument(
+        "-r",
+        "--resource",
+        action="store",
+        help="Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)",
+        default="https://graph.windows.net",
+    )
+    injauth_parser.add_argument(
+        "-s",
+        "--scope",
+        action="store",
+        help="Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.",
+    )
+    injauth_parser.add_argument(
+        "-ru",
+        "--redirect-url",
+        action="store",
+        metavar="URL",
+        help="Redirect URL used when authenticating (default: chosen automatically based on well-known URLs for first party clients)",
+    )
+    injauth_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. Default: Chrome on Windows user agent",
+    )
+    injauth_parser.add_argument(
+        "-t", "--tenant", action="store", help="Tenant ID or domain to auth to"
+    )
+    injauth_parser.add_argument(
+        "-d",
+        "--driver-path",
+        action="store",
+        help="Path to geckodriver file on disk (download from: https://github.com/mozilla/geckodriver/releases)",
+    )
+    injauth_parser.add_argument(
+        "-k",
+        "--keep-open",
+        action="store_true",
+        help="Do not close the browser window after timeout. Useful if you want to browse online apps with the obtained credentials",
+    )
+    injauth_parser.add_argument(
+        "-f",
+        "--prt-file",
+        default="roadtx.prt",
+        action="store",
+        metavar="FILE",
+        help="PRT storage file (default: roadtx.prt)",
+    )
+    injauth_parser.add_argument("--prt", action="store", help="Primary Refresh Token")
+    injauth_parser.add_argument(
+        "--prt-sessionkey",
+        action="store",
+        help="Primary Refresh Token session key (as hex key)",
+    )
+    injauth_parser.add_argument(
+        "--prt-cookie",
+        action="store",
+        help="Primary Refresh Token cookie from ROADtoken (JWT)",
+    )
+    injauth_parser.add_argument(
+        "--tokenfile",
+        action="store",
+        help="File to store the credentials (default: .roadtools_auth)",
+        default=".roadtools_auth",
+    )
+    injauth_parser.add_argument(
+        "--tokens-stdout",
+        action="store_true",
+        help="Do not store tokens on disk, pipe to stdout instead",
+    )
+    injauth_parser.add_argument(
+        "--cae",
+        action="store_true",
+        help="Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)",
+    )
+    injauth_parser.add_argument(
+        "--force-mfa", action="store_true", help="Force MFA during authentication"
+    )
+    injauth_parser.add_argument(
+        "--pkce", action="store_true", help="Use PKCE during authentication"
+    )
+    injauth_parser.add_argument(
+        "--origin",
+        action="store",
+        help="Origin header to use in code redemption (for single page app flows)",
+    )
+    injauth_parser.add_argument(
+        "--otpseed",
+        action="store",
+        help="TOTP seed to calculate MFA code when prompted",
+    )
 
     # Interactive auth using Selenium - enrich PRT
-    enrauth_parser = subparsers.add_parser('prtenrich', help='Interactive authentication to add MFA claim to a PRT')
-    enrauth_parser.add_argument('-u', '--username', action='store', metavar='USER', help='User in the prt')
-    enrauth_parser.add_argument('-kp', '--keepass', action='store', metavar='KPFILE', default='roadtx.kdbx', help='KeePass file (default: roadtx.kdbx)')
-    enrauth_parser.add_argument('-kpp', '--keepass-password', action='store', metavar='KPPASS', help='KeePass file password. Can also be provided via KPPASS environment variable.')
-    enrauth_parser.add_argument('-d', '--driver-path',
-                                action='store',
-                                help='Path to geckodriver file on disk (download from: https://github.com/mozilla/geckodriver/releases)')
-    enrauth_parser.add_argument('-f', '--prt-file', default="roadtx.prt", action='store', metavar='FILE', help='PRT storage file (default: roadtx.prt)')
-    enrauth_parser.add_argument('-ua', '--user-agent', action='store',
-                                help='Custom user agent to use. Default: Chrome on Windows user agent')
-    enrauth_parser.add_argument('--no-prt', action='store_true', help='Perform the flow without a PRT')
-    enrauth_parser.add_argument('--prt',
-                                action='store',
-                                help='Primary Refresh Token')
-    enrauth_parser.add_argument('--prt-sessionkey',
-                                action='store',
-                                help='Primary Refresh Token session key (as hex key)')
-    enrauth_parser.add_argument('--ngcmfa-drs-auth', action='store_true', help="Don't request PRT with MFA claim but get access token with ngcmfa claim for DRS instead.")
-    enrauth_parser.add_argument('--tokenfile',
-                                action='store',
-                                help='File to store the credentials (default: .roadtools_auth)',
-                                default='.roadtools_auth')
-    enrauth_parser.add_argument('--tokens-stdout',
-                                action='store_true',
-                                help='Do not store tokens on disk, pipe to stdout instead')
-    enrauth_parser.add_argument('--otpseed',
-                                action='store',
-                                help='TOTP seed to calculate MFA code when prompted')
+    enrauth_parser = subparsers.add_parser(
+        "prtenrich", help="Interactive authentication to add MFA claim to a PRT"
+    )
+    enrauth_parser.add_argument(
+        "-u", "--username", action="store", metavar="USER", help="User in the prt"
+    )
+    enrauth_parser.add_argument(
+        "-kp",
+        "--keepass",
+        action="store",
+        metavar="KPFILE",
+        default="roadtx.kdbx",
+        help="KeePass file (default: roadtx.kdbx)",
+    )
+    enrauth_parser.add_argument(
+        "-kpp",
+        "--keepass-password",
+        action="store",
+        metavar="KPPASS",
+        help="KeePass file password. Can also be provided via KPPASS environment variable.",
+    )
+    enrauth_parser.add_argument(
+        "-d",
+        "--driver-path",
+        action="store",
+        help="Path to geckodriver file on disk (download from: https://github.com/mozilla/geckodriver/releases)",
+    )
+    enrauth_parser.add_argument(
+        "-f",
+        "--prt-file",
+        default="roadtx.prt",
+        action="store",
+        metavar="FILE",
+        help="PRT storage file (default: roadtx.prt)",
+    )
+    enrauth_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. Default: Chrome on Windows user agent",
+    )
+    enrauth_parser.add_argument(
+        "--no-prt", action="store_true", help="Perform the flow without a PRT"
+    )
+    enrauth_parser.add_argument("--prt", action="store", help="Primary Refresh Token")
+    enrauth_parser.add_argument(
+        "--prt-sessionkey",
+        action="store",
+        help="Primary Refresh Token session key (as hex key)",
+    )
+    enrauth_parser.add_argument(
+        "--ngcmfa-drs-auth",
+        action="store_true",
+        help="Don't request PRT with MFA claim but get access token with ngcmfa claim for DRS instead.",
+    )
+    enrauth_parser.add_argument(
+        "--tokenfile",
+        action="store",
+        help="File to store the credentials (default: .roadtools_auth)",
+        default=".roadtools_auth",
+    )
+    enrauth_parser.add_argument(
+        "--tokens-stdout",
+        action="store_true",
+        help="Do not store tokens on disk, pipe to stdout instead",
+    )
+    enrauth_parser.add_argument(
+        "--otpseed",
+        action="store",
+        help="TOTP seed to calculate MFA code when prompted",
+    )
 
     # CLI authentication with device code flow
-    cliauth_parser = subparsers.add_parser('clicodeauth', help='Manual interactive authentication with external browser')
-    cliauth_parser.add_argument('-c',
-                                '--client',
-                                action='store',
-                                help=clienthelptext,
-                                default='1b730954-1685-4b74-9bfd-dac224a7b894')
-    cliauth_parser.add_argument('-r',
-                                '--resource',
-                                action='store',
-                                help='Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)',
-                                default='https://graph.windows.net')
-    cliauth_parser.add_argument('-s',
-                                '--scope',
-                                action='store',
-                                help='Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.')
-    cliauth_parser.add_argument('-ru', '--redirect-url', action='store', metavar='URL',
-                                help='Redirect URL used when authenticating (default: chosen automatically based on well-known URLs for first party clients)')
-    cliauth_parser.add_argument('-t',
-                                '--tenant',
-                                action='store',
-                                help='Tenant ID or domain to auth to')
-    cliauth_parser.add_argument('--tokenfile',
-                                action='store',
-                                help='File to store the credentials (default: .roadtools_auth)',
-                                default='.roadtools_auth')
-    cliauth_parser.add_argument('--tokens-stdout',
-                                action='store_true',
-                                help='Do not store tokens on disk, pipe to stdout instead')
-    cliauth_parser.add_argument('--capture-code',
-                                action='store_true',
-                                help='Do not attempt to redeem any authentication code but print it instead')
-    cliauth_parser.add_argument('--cae',
-                                action='store_true',
-                                help='Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)')
-    cliauth_parser.add_argument('--force-mfa',
-                                action='store_true',
-                                help='Force MFA during authentication')
-    cliauth_parser.add_argument('--pkce',
-                                action='store_true',
-                                help='Use PKCE during authentication')
-    cliauth_parser.add_argument('--origin',
-                                action='store',
-                                help='Origin header to use in code redemption (for single page app flows)')
+    cliauth_parser = subparsers.add_parser(
+        "clicodeauth", help="Manual interactive authentication with external browser"
+    )
+    cliauth_parser.add_argument(
+        "-c",
+        "--client",
+        action="store",
+        help=clienthelptext,
+        default="1b730954-1685-4b74-9bfd-dac224a7b894",
+    )
+    cliauth_parser.add_argument(
+        "-r",
+        "--resource",
+        action="store",
+        help="Resource to authenticate to. Either a full URL or alias (list with roadtx listaliases)",
+        default="https://graph.windows.net",
+    )
+    cliauth_parser.add_argument(
+        "-s",
+        "--scope",
+        action="store",
+        help="Scope to use. Will automatically switch to v2.0 auth endpoint if specified. If unsure use -r instead.",
+    )
+    cliauth_parser.add_argument(
+        "-ru",
+        "--redirect-url",
+        action="store",
+        metavar="URL",
+        help="Redirect URL used when authenticating (default: chosen automatically based on well-known URLs for first party clients)",
+    )
+    cliauth_parser.add_argument(
+        "-t", "--tenant", action="store", help="Tenant ID or domain to auth to"
+    )
+    cliauth_parser.add_argument(
+        "--tokenfile",
+        action="store",
+        help="File to store the credentials (default: .roadtools_auth)",
+        default=".roadtools_auth",
+    )
+    cliauth_parser.add_argument(
+        "--tokens-stdout",
+        action="store_true",
+        help="Do not store tokens on disk, pipe to stdout instead",
+    )
+    cliauth_parser.add_argument(
+        "--capture-code",
+        action="store_true",
+        help="Do not attempt to redeem any authentication code but print it instead",
+    )
+    cliauth_parser.add_argument(
+        "--cae",
+        action="store_true",
+        help="Request Continuous Access Evaluation tokens (requires use of scope parameter instead of resource)",
+    )
+    cliauth_parser.add_argument(
+        "--force-mfa", action="store_true", help="Force MFA during authentication"
+    )
+    cliauth_parser.add_argument(
+        "--pkce", action="store_true", help="Use PKCE during authentication"
+    )
+    cliauth_parser.add_argument(
+        "--origin",
+        action="store",
+        help="Origin header to use in code redemption (for single page app flows)",
+    )
 
     # OWA Login with token
-    owalogin_parser = subparsers.add_parser('owalogin', help='Login to OWA with token')
-    owalogin_parser.add_argument('--access-token', action='store', help='Access token for Outlook. If not specified, taken from .roadtools_auth')
-    owalogin_parser.add_argument('-ua', '--user-agent', action='store',
-                                 help='Custom user agent to use. By default the user agent from FireFox is used without modification')
-    owalogin_parser.add_argument('-f', '--tokenfile', action='store', help='File to read the token from (default: .roadtools_auth)', default='.roadtools_auth')
+    owalogin_parser = subparsers.add_parser("owalogin", help="Login to OWA with token")
+    owalogin_parser.add_argument(
+        "--access-token",
+        action="store",
+        help="Access token for Outlook. If not specified, taken from .roadtools_auth",
+    )
+    owalogin_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. By default the user agent from FireFox is used without modification",
+    )
+    owalogin_parser.add_argument(
+        "-f",
+        "--tokenfile",
+        action="store",
+        help="File to read the token from (default: .roadtools_auth)",
+        default=".roadtools_auth",
+    )
 
     # SPO Login with token
-    spologin_parser = subparsers.add_parser('sharepointlogin', help='Login to SharePoint with token')
-    spologin_parser.add_argument('--access-token', action='store', help='Access token for SharePoint / OneDrive. If not specified, taken from .roadtools_auth')
-    spologin_parser.add_argument('-ua', '--user-agent', action='store',
-                                 help='Custom user agent to use. By default the user agent from FireFox is used without modification')
-    spologin_parser.add_argument('--host', action='store', help='SharePoint host to use, for example: https://mycompany-my.sharepoint.com if unspecified, taken from access token')
-    spologin_parser.add_argument('-f', '--tokenfile', action='store', help='File to read the token from (default: .roadtools_auth)', default='.roadtools_auth')
+    spologin_parser = subparsers.add_parser(
+        "sharepointlogin", help="Login to SharePoint with token"
+    )
+    spologin_parser.add_argument(
+        "--access-token",
+        action="store",
+        help="Access token for SharePoint / OneDrive. If not specified, taken from .roadtools_auth",
+    )
+    spologin_parser.add_argument(
+        "-ua",
+        "--user-agent",
+        action="store",
+        help="Custom user agent to use. By default the user agent from FireFox is used without modification",
+    )
+    spologin_parser.add_argument(
+        "--host",
+        action="store",
+        help="SharePoint host to use, for example: https://mycompany-my.sharepoint.com if unspecified, taken from access token",
+    )
+    spologin_parser.add_argument(
+        "-f",
+        "--tokenfile",
+        action="store",
+        help="File to read the token from (default: .roadtools_auth)",
+        default=".roadtools_auth",
+    )
 
     # ADFS Encrypted blob decrypt
-    adfsdec_parser = subparsers.add_parser('decryptadfskey', help='Decrypt Encrypted PFX blob from ADFSpoof into PEM or PFX file')
-    adfsdec_parser.add_argument('-c', '--cert-pem', action='store', metavar='file', default='roadtx_adfs.pem', help='Certificate file to save ADFS cert (default: roadtx_adfs.pem)')
-    adfsdec_parser.add_argument('-k', '--key-pem', action='store', metavar='file', default='roadtx_adfs.key', help='Private key file to save ADFS key (default: roadtx_adfs.key)')
-    adfsdec_parser.add_argument('--cert-pfx', action='store', metavar='file', default='roadtx_adfs.pfx', help='File to store the key (default: roadtx_adfs.pfx)')
-    adfsdec_parser.add_argument('-o', '--output-format', action='store', metavar='format', default='pem', choices=['pem', 'pfx'], help='Output format (pem or pfx), default: pem')
-    adfsdec_parser.add_argument('encryptedpfx', action='store', metavar='pfxblob', help='EncryptedPFX data from ADFSpoof')
-    adfsdec_parser.add_argument('key', action='store', metavar='key', help='Decryption key (DKM key)')
-    adfsdec_parser.add_argument('-v', '--verbose', action='store_true', help='Show extra information')
+    adfsdec_parser = subparsers.add_parser(
+        "decryptadfskey",
+        help="Decrypt Encrypted PFX blob from ADFSpoof into PEM or PFX file",
+    )
+    adfsdec_parser.add_argument(
+        "-c",
+        "--cert-pem",
+        action="store",
+        metavar="file",
+        default="roadtx_adfs.pem",
+        help="Certificate file to save ADFS cert (default: roadtx_adfs.pem)",
+    )
+    adfsdec_parser.add_argument(
+        "-k",
+        "--key-pem",
+        action="store",
+        metavar="file",
+        default="roadtx_adfs.key",
+        help="Private key file to save ADFS key (default: roadtx_adfs.key)",
+    )
+    adfsdec_parser.add_argument(
+        "--cert-pfx",
+        action="store",
+        metavar="file",
+        default="roadtx_adfs.pfx",
+        help="File to store the key (default: roadtx_adfs.pfx)",
+    )
+    adfsdec_parser.add_argument(
+        "-o",
+        "--output-format",
+        action="store",
+        metavar="format",
+        default="pem",
+        choices=["pem", "pfx"],
+        help="Output format (pem or pfx), default: pem",
+    )
+    adfsdec_parser.add_argument(
+        "encryptedpfx",
+        action="store",
+        metavar="pfxblob",
+        help="EncryptedPFX data from ADFSpoof",
+    )
+    adfsdec_parser.add_argument(
+        "key", action="store", metavar="key", help="Decryption key (DKM key)"
+    )
+    adfsdec_parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Show extra information"
+    )
 
     # ADFS token generation
-    samltoken_parser = subparsers.add_parser('samltoken', help='Create a SAML token using an AD FS key')
-    samltoken_parser.add_argument('-c', '--cert-pem', action='store', metavar='file', help='Certificate file with AD FS cert')
-    samltoken_parser.add_argument('-k', '--key-pem', action='store', metavar='file', help='Private key file with AD FS key')
-    samltoken_parser.add_argument('--cert-pfx', action='store', metavar='file', help='PFX file with AD FS cert/key')
-    samltoken_parser.add_argument('--pfx-pass', action='store', metavar='password', help='PFX file password')
-    samltoken_parser.add_argument('--pfx-base64', action='store', metavar='BASE64', help='PFX file as base64 string')
-    samltoken_parser.add_argument('-i', '--issuer', action='store', required=True, help='Token issuer, must match the federated domain name (without http/https, example: federated.mycompany.com)')
-    samltoken_parser.add_argument('-u', '--unique-id', action='store', help='Unique ID of user to spoof (immutableId in roadrecon)')
-    samltoken_parser.add_argument('-g', '--guid', action='store', help='GUID of user to spoof (from AD), if not specifying the unique id')
-    samltoken_parser.add_argument('-m', '--mfa', action='store_true', help='Include MFA claim in token')
-    samltoken_parser.add_argument('--upn', action='store', required=True, help='userPrincipalName of user to spoof')
+    samltoken_parser = subparsers.add_parser(
+        "samltoken", help="Create a SAML token using an AD FS key"
+    )
+    samltoken_parser.add_argument(
+        "-c",
+        "--cert-pem",
+        action="store",
+        metavar="file",
+        help="Certificate file with AD FS cert",
+    )
+    samltoken_parser.add_argument(
+        "-k",
+        "--key-pem",
+        action="store",
+        metavar="file",
+        help="Private key file with AD FS key",
+    )
+    samltoken_parser.add_argument(
+        "--cert-pfx",
+        action="store",
+        metavar="file",
+        help="PFX file with AD FS cert/key",
+    )
+    samltoken_parser.add_argument(
+        "--pfx-pass", action="store", metavar="password", help="PFX file password"
+    )
+    samltoken_parser.add_argument(
+        "--pfx-base64",
+        action="store",
+        metavar="BASE64",
+        help="PFX file as base64 string",
+    )
+    samltoken_parser.add_argument(
+        "-i",
+        "--issuer",
+        action="store",
+        required=True,
+        help="Token issuer, must match the federated domain name (without http/https, example: federated.mycompany.com)",
+    )
+    samltoken_parser.add_argument(
+        "-u",
+        "--unique-id",
+        action="store",
+        help="Unique ID of user to spoof (immutableId in roadrecon)",
+    )
+    samltoken_parser.add_argument(
+        "-g",
+        "--guid",
+        action="store",
+        help="GUID of user to spoof (from AD), if not specifying the unique id",
+    )
+    samltoken_parser.add_argument(
+        "-m", "--mfa", action="store_true", help="Include MFA claim in token"
+    )
+    samltoken_parser.add_argument(
+        "--upn",
+        action="store",
+        required=True,
+        help="userPrincipalName of user to spoof",
+    )
 
     # PRT cookie creations
-    prtcookie_parser = subparsers.add_parser('prtcookie', help='Create a PRT cookie from a PRT for external usage')
-    prtcookie_parser.add_argument('-f', '--prt-file', default="roadtx.prt", action='store', metavar='FILE', help='PRT storage file (default: roadtx.prt)')
-    prtcookie_parser.add_argument('--prt',
-                                  action='store',
-                                  help='Primary Refresh Token')
-    prtcookie_parser.add_argument('--prt-sessionkey',
-                                  action='store',
-                                  help='Primary Refresh Token session key (as hex key)')
+    prtcookie_parser = subparsers.add_parser(
+        "prtcookie", help="Create a PRT cookie from a PRT for external usage"
+    )
+    prtcookie_parser.add_argument(
+        "-f",
+        "--prt-file",
+        default="roadtx.prt",
+        action="store",
+        metavar="FILE",
+        help="PRT storage file (default: roadtx.prt)",
+    )
+    prtcookie_parser.add_argument("--prt", action="store", help="Primary Refresh Token")
+    prtcookie_parser.add_argument(
+        "--prt-sessionkey",
+        action="store",
+        help="Primary Refresh Token session key (as hex key)",
+    )
 
     if len(sys.argv) < 2:
         parser.print_help()
-        sys.exit(1)
         return
 
     args = parser.parse_args()
+
+    if args.client is not None:
+        auth.set_client_id(args.client)
+        enrich_args_from_firstparty(auth.client_id, args)
+
     deviceauth = DeviceAuthentication(auth)
 
     if args.proxy:
         auth.proxies = deviceauth.proxies = {
-            'https': f'{args.proxy_type}://{args.proxy}'
+            "https": f"{args.proxy_type}://{args.proxy}"
         }
         if not args.secure:
             auth.verify = deviceauth.verify = False
 
-    if args.command in ('auth', 'gettokens', 'gettoken'):
+    if args.command in ("auth", "gettokens", "gettoken"):
         auth.parse_args(args)
         if not args.tokens_stdout:
             if args.scope:
-                print(f'Requesting token with scope {auth.scope}')
+                print(f"Requesting token with scope {auth.scope}")
             else:
-                print(f'Requesting token for resource {auth.resource_uri}')
+                print(f"Requesting token for resource {auth.resource_uri}")
         res = auth.get_tokens(args)
         if not res:
             return
         auth.save_tokens(args)
-    elif args.command == 'refreshtokento':
+    elif args.command == "refreshtokento":
         if args.refresh_token:
             if not args.client:
-                print('The client argument (-c) is required when specifying a custom refresh token')
+                print(
+                    "The client argument (-c) is required when specifying a custom refresh token"
+                )
                 return
             # Allow overriding the token
-            tokenobject = {
-                'refreshToken':args.refresh_token,
-                '_clientId': args.client
-            }
+            tokenobject = {"refreshToken": args.refresh_token, "_clientId": args.client}
         else:
             try:
-                with codecs.open('.roadtools_auth', 'r', 'utf-8') as infile:
+                with codecs.open(".roadtools_auth", "r", "utf-8") as infile:
                     tokenobject = json.load(infile)
-                _, tokendata = auth.parse_accesstoken(tokenobject['accessToken'])
+                _, tokendata = auth.parse_accesstoken(tokenobject["accessToken"])
             except FileNotFoundError:
-                print('This command requires the .roadtools_auth file, which was not found. Use the gettokens command to supply a refresh token manually.')
+                print(
+                    "This command requires the .roadtools_auth file, which was not found. Use the gettokens command to supply a refresh token manually."
+                )
                 return
         auth.set_resource_uri(args.resource)
         auth.set_user_agent(args.user_agent)
@@ -969,19 +2049,20 @@ def main():
         auth.outfile = args.tokenfile
         if args.origin:
             auth.set_origin_value(args.origin)
-        elif 'originheader' in tokenobject:
-            auth.set_origin_value(tokenobject['originheader'])
+        elif "originheader" in tokenobject:
+            auth.set_origin_value(tokenobject["originheader"])
         # Tenant from arguments or from tokenfile
         if args.tenant:
             auth.tenant = args.tenant
-        elif 'tenantId' in tokenobject:
-            auth.tenant = tokenobject['tenantId']
-        if args.client:
-            auth.set_client_id(args.client)
-        elif '_clientId' in tokenobject:
-            auth.set_client_id(tokenobject['_clientId'])
+        elif "tenantId" in tokenobject:
+            auth.tenant = tokenobject["tenantId"]
+
+        if "_clientId" in tokenobject:
+            auth.set_client_id(tokenobject["_clientId"])
         else:
-            print('Could not determine client ID of refresh token, please specify with -c')
+            print(
+                "Could not determine client ID of refresh token, please specify with -c"
+            )
             return
         if args.cae:
             auth.use_cae = args.cae
@@ -990,65 +2071,81 @@ def main():
 
             # Load scope data - contains redirect URLs for the broker
             current_dir = os.path.abspath(os.path.dirname(__file__))
-            datafile = os.path.join(current_dir, 'firstpartyscopes.json')
-            with codecs.open(datafile,'r','utf-8') as infile:
+            datafile = os.path.join(current_dir, "firstpartyscopes.json")
+            with codecs.open(datafile, "r", "utf-8") as infile:
                 data = json.load(infile)
             if not args.client:
-                print('Client ID is required for autobroker flag, please specify with -c')
+                print(
+                    "Client ID is required for autobroker flag, please specify with -c"
+                )
                 return
             if args.broker_client:
                 originclient = auth.lookup_client_id(args.broker_client)
-            elif '_clientId' in tokenobject:
-                originclient = auth.lookup_client_id(tokenobject['_clientId'])
+            elif "_clientId" in tokenobject:
+                originclient = auth.lookup_client_id(tokenobject["_clientId"])
             else:
-                print('Could not determine client, guessing the client based on redirect URL found')
-                originclient = 'guess'
+                print(
+                    "Could not determine client, guessing the client based on redirect URL found"
+                )
+                originclient = "guess"
             try:
-                targetclient = data['apps'][auth.lookup_client_id(args.client)]
+                targetclient = data["apps"][auth.lookup_client_id(args.client)]
             except KeyError:
-                print(f'Unknown client with ID {args.client} is not found in roadtx built-in client list. Please specify broker parameters manually.')
+                print(
+                    f"Unknown client with ID {args.client} is not found in roadtx built-in client list. Please specify broker parameters manually."
+                )
                 return
             validru = False
-            for redirect_url in targetclient['redirect_uris']:
-                if originclient == 'guess' and redirect_url.startswith('brk-'):
+            for redirect_url in targetclient["redirect_uris"]:
+                if originclient == "guess" and redirect_url.startswith("brk-"):
                     validru = True
                     finalru = redirect_url
                     break
-                if redirect_url.startswith(f'brk-{originclient}'):
+                if redirect_url.startswith(f"brk-{originclient}"):
                     validru = True
                     finalru = redirect_url
                     break
             if not validru:
-                print(f'Could not find a valid broker redirect URL on this client matching the original client ID {originclient}')
+                print(
+                    f"Could not find a valid broker redirect URL on this client matching the original client ID {originclient}"
+                )
                 return
             parsed = urlparse(finalru)
-            if originclient == 'guess':
+            if originclient == "guess":
                 # We know the client ID now
                 originclient = parsed.scheme.lower()[4:]
             # Copy correct origin
-            auth.set_origin_value(f'https://{parsed.hostname}')
+            auth.set_origin_value(f"https://{parsed.hostname}")
             args.broker_redirect_url = finalru
             args.broker_client = originclient
         if not args.tokens_stdout:
             if args.scope:
-                print(f'Requesting token with scope {auth.scope}')
+                print(f"Requesting token with scope {auth.scope}")
             else:
-                print(f'Requesting token for resource {auth.resource_uri}')
+                print(f"Requesting token for resource {auth.resource_uri}")
         try:
             if args.broker_client:
                 additionaldata = {
-                    'brk_client_id': args.broker_client,
-                    'redirect_uri': args.broker_redirect_url
+                    "brk_client_id": args.broker_client,
+                    "redirect_uri": args.broker_redirect_url,
                 }
             else:
                 additionaldata = None
             if args.scope:
-                auth.authenticate_with_refresh_native_v2(tokenobject['refreshToken'], client_secret=args.password, additionaldata=additionaldata)
+                auth.authenticate_with_refresh_native_v2(
+                    tokenobject["refreshToken"],
+                    client_secret=args.password,
+                    additionaldata=additionaldata,
+                )
             else:
-                auth.authenticate_with_refresh_native(tokenobject['refreshToken'], client_secret=args.password, additionaldata=additionaldata)
+                auth.authenticate_with_refresh_native(
+                    tokenobject["refreshToken"],
+                    client_secret=args.password,
+                    additionaldata=additionaldata,
+                )
             # Save original client ID if doing broker auth
             if args.broker_client:
-                auth.tokendata['_clientId'] = args.broker_client
+                auth.tokendata["_clientId"] = args.broker_client
             auth.save_tokens(args)
         except AuthenticationException as ex:
             try:
@@ -1058,8 +2155,8 @@ def main():
                 # No json
                 print(str(ex))
             sys.exit(1)
-    elif args.command == 'appauth':
-        auth.set_client_id(args.client)
+    elif args.command == "appauth":
+
         auth.set_resource_uri(args.resource)
         auth.set_scope(args.scope)
         if args.cae:
@@ -1068,9 +2165,9 @@ def main():
         auth.outfile = args.tokenfile
         if not args.tokens_stdout:
             if args.scope:
-                print(f'Requesting token with scope {auth.scope}')
+                print(f"Requesting token with scope {auth.scope}")
             else:
-                print(f'Requesting token for resource {auth.resource_uri}')
+                print(f"Requesting token for resource {auth.resource_uri}")
         if args.password:
             # Password based flow
             if args.scope:
@@ -1083,7 +2180,13 @@ def main():
             else:
                 auth.authenticate_as_app_native(assertion=args.assertion)
         else:
-            if not auth.loadappcert(args.cert_pem, args.key_pem, args.cert_pfx, args.pfx_pass, args.pfx_base64):
+            if not auth.loadappcert(
+                args.cert_pem,
+                args.key_pem,
+                args.cert_pfx,
+                args.pfx_pass,
+                args.pfx_base64,
+            ):
                 return
             if args.scope:
                 assertion = auth.generate_app_assertion(use_v2=True)
@@ -1092,8 +2195,8 @@ def main():
                 assertion = auth.generate_app_assertion(use_v2=False)
                 auth.authenticate_as_app_native(assertion=assertion)
         auth.save_tokens(args)
-    elif args.command == 'appauthobo':
-        auth.set_client_id(args.client)
+    elif args.command == "appauthobo":
+
         auth.set_resource_uri(args.resource)
         auth.set_scope(args.scope)
         if args.cae:
@@ -1102,27 +2205,41 @@ def main():
         auth.outfile = args.tokenfile
         if not args.tokens_stdout:
             if args.scope:
-                print(f'Requesting token with scope {auth.scope}')
+                print(f"Requesting token with scope {auth.scope}")
             else:
-                print(f'Requesting token for resource {auth.resource_uri}')
+                print(f"Requesting token for resource {auth.resource_uri}")
         if args.password:
             # Password based flow
             if args.scope:
-                auth.authenticate_on_behalf_of_native_v2(token=args.token, client_secret=args.password)
+                auth.authenticate_on_behalf_of_native_v2(
+                    token=args.token, client_secret=args.password
+                )
             else:
-                auth.authenticate_on_behalf_of_native(token=args.token, client_secret=args.password)
+                auth.authenticate_on_behalf_of_native(
+                    token=args.token, client_secret=args.password
+                )
         else:
-            if not auth.loadappcert(args.cert_pem, args.key_pem, args.cert_pfx, args.pfx_pass, args.pfx_base64):
+            if not auth.loadappcert(
+                args.cert_pem,
+                args.key_pem,
+                args.cert_pfx,
+                args.pfx_pass,
+                args.pfx_base64,
+            ):
                 return
             if args.scope:
                 assertion = auth.generate_app_assertion(use_v2=True)
-                auth.authenticate_on_behalf_of_native_v2(token=args.token, assertion=assertion)
+                auth.authenticate_on_behalf_of_native_v2(
+                    token=args.token, assertion=assertion
+                )
             else:
                 assertion = auth.generate_app_assertion(use_v2=False)
-                auth.authenticate_on_behalf_of_native(token=args.token, assertion=assertion)
+                auth.authenticate_on_behalf_of_native(
+                    token=args.token, assertion=assertion
+                )
         auth.save_tokens(args)
-    elif args.command == 'federatedappauth':
-        auth.set_client_id(args.client)
+    elif args.command == "federatedappauth":
+
         auth.set_resource_uri(args.resource)
         auth.set_scope(args.scope)
         if args.cae:
@@ -1131,52 +2248,88 @@ def main():
         auth.outfile = args.tokenfile
         if not args.tokens_stdout:
             if args.scope:
-                print(f'Requesting token with scope {auth.scope}')
+                print(f"Requesting token with scope {auth.scope}")
             else:
-                print(f'Requesting token for resource {auth.resource_uri}')
-        if not auth.loadappcert(args.cert_pem, args.key_pem, args.cert_pfx, args.pfx_pass, args.pfx_base64):
+                print(f"Requesting token for resource {auth.resource_uri}")
+        if not auth.loadappcert(
+            args.cert_pem, args.key_pem, args.cert_pfx, args.pfx_pass, args.pfx_base64
+        ):
             return
-        assertion = auth.generate_federated_assertion(iss=args.issuer, sub=args.subject, kid=args.kid, aud=args.audience)
+        assertion = auth.generate_federated_assertion(
+            iss=args.issuer, sub=args.subject, kid=args.kid, aud=args.audience
+        )
         if args.scope:
             auth.authenticate_as_app_native_v2(assertion=assertion)
         else:
             auth.authenticate_as_app_native(assertion=assertion)
         auth.save_tokens(args)
-    elif args.command == 'device':
+    elif args.command == "device":
         auth.set_user_agent(args.user_agent)
-        if args.action in ('register', 'join'):
+        if args.action in ("register", "join"):
             if args.access_token:
                 tokenobject, tokendata = auth.parse_accesstoken(args.access_token)
             else:
                 try:
-                    with codecs.open('.roadtools_auth', 'r', 'utf-8') as infile:
+                    with codecs.open(".roadtools_auth", "r", "utf-8") as infile:
                         tokenobject = json.load(infile)
-                    _, tokendata = auth.parse_accesstoken(tokenobject['accessToken'])
+                    _, tokendata = auth.parse_accesstoken(tokenobject["accessToken"])
                 except FileNotFoundError:
-                    print('No auth data found. Ether supply an access token with --access-token or make sure a token is present on disk in .roadtools_auth')
+                    print(
+                        "No auth data found. Ether supply an access token with --access-token or make sure a token is present on disk in .roadtools_auth"
+                    )
                     return
-            if tokendata['aud'] != 'urn:ms-drs:enterpriseregistration.windows.net':
-                print(f"Wrong token audience, got {tokendata['aud']} but expected: urn:ms-drs:enterpriseregistration.windows.net")
-                print("Make sure to request a token with -r urn:ms-drs:enterpriseregistration.windows.net")
+            if tokendata["aud"] != "urn:ms-drs:enterpriseregistration.windows.net":
+                print(
+                    f"Wrong token audience, got {tokendata['aud']} but expected: urn:ms-drs:enterpriseregistration.windows.net"
+                )
+                print(
+                    "Make sure to request a token with -r urn:ms-drs:enterpriseregistration.windows.net"
+                )
                 return
-            if args.action == 'join':
+            if args.action == "join":
                 jointype = 0
             else:
                 jointype = 4
-            deviceauth.register_device(tokenobject['accessToken'], jointype=jointype, certout=args.cert_pem, privout=args.key_pem, device_type=args.device_type, device_name=args.name, os_version=args.os_version, deviceticket=args.deviceticket, device_domain=args.domain)
-        elif args.action == 'delete':
+            deviceauth.register_device(
+                tokenobject["accessToken"],
+                jointype=jointype,
+                certout=args.cert_pem,
+                privout=args.key_pem,
+                device_type=args.device_type,
+                device_name=args.name,
+                os_version=args.os_version,
+                deviceticket=args.deviceticket,
+                device_domain=args.domain,
+            )
+        elif args.action == "delete":
             if not deviceauth.loadcert(args.cert_pem, args.key_pem):
                 return
             deviceauth.delete_device(args.cert_pem, args.key_pem)
-    elif args.command == 'hybriddevice':
+    elif args.command == "hybriddevice":
         auth.set_user_agent(args.user_agent)
-        if not deviceauth.loadcert(args.cert_pem, args.key_pem, args.cert_pfx, args.pfx_pass, args.pfx_base64):
+        if not deviceauth.loadcert(
+            args.cert_pem, args.key_pem, args.cert_pfx, args.pfx_pass, args.pfx_base64
+        ):
             return
-        deviceauth.register_hybrid_device(args.sid, args.tenant, certout=args.cert_pem, privout=args.key_pem, device_type=args.device_type, device_name=args.name, os_version=args.os_version)
-    elif args.command == 'prt':
+        deviceauth.register_hybrid_device(
+            args.sid,
+            args.tenant,
+            certout=args.cert_pem,
+            privout=args.key_pem,
+            device_type=args.device_type,
+            device_name=args.name,
+            os_version=args.os_version,
+        )
+    elif args.command == "prt":
         auth.set_user_agent(args.user_agent)
-        if args.action == 'request':
-            if not deviceauth.loadcert(args.cert_pem, args.key_pem, args.cert_pfx, args.pfx_pass, args.pfx_base64):
+        if args.action == "request":
+            if not deviceauth.loadcert(
+                args.cert_pem,
+                args.key_pem,
+                args.cert_pfx,
+                args.pfx_pass,
+                args.pfx_base64,
+            ):
                 return
             if args.transport_key_pem:
                 # Try loading transport key separately
@@ -1186,19 +2339,19 @@ def main():
             if args.username and args.password:
                 prtdata = deviceauth.get_prt_with_password(args.username, args.password)
             if args.saml_token:
-                if args.saml_token.lower() == 'stdin':
+                if args.saml_token.lower() == "stdin":
                     samltoken = sys.stdin.read()
                 else:
                     samltoken = args.saml_token
                 prtdata = deviceauth.get_prt_with_samltoken(samltoken)
             if args.refresh_token:
-                if args.refresh_token.lower() == 'file':
-                    with codecs.open('.roadtools_auth', 'r', 'utf-8') as infile:
+                if args.refresh_token.lower() == "file":
+                    with codecs.open(".roadtools_auth", "r", "utf-8") as infile:
                         tokenobject = json.load(infile)
                     try:
-                        refresh_token = tokenobject['refreshToken']
+                        refresh_token = tokenobject["refreshToken"]
                     except KeyError:
-                        print('No refresh token found in token file!')
+                        print("No refresh token found in token file!")
                         return
                 else:
                     refresh_token = args.refresh_token
@@ -1210,34 +2363,42 @@ def main():
             if args.username and deviceauth.loadhellokey(args.hello_key):
                 prtdata = deviceauth.get_prt_with_hello_key(args.username)
             if args.username and args.hello_assertion:
-                prtdata = deviceauth.get_prt_with_hello_key(args.username, args.hello_assertion)
+                prtdata = deviceauth.get_prt_with_hello_key(
+                    args.username, args.hello_assertion
+                )
             if not prtdata:
-                print('You must specify a username + password or refresh token that can be used to request a PRT')
+                print(
+                    "You must specify a username + password or refresh token that can be used to request a PRT"
+                )
                 return
             print(f"Obtained PRT: {prtdata['refresh_token']}")
             print(f"Obtained session key: {prtdata['session_key']}")
             deviceauth.saveprt(prtdata, args.prt_file)
-        if args.action == 'renew':
+        if args.action == "renew":
             if args.prt and args.prt_sessionkey:
                 deviceauth.setprt(args.prt, args.prt_sessionkey)
             elif args.prt_file and deviceauth.loadprt(args.prt_file):
                 pass
             else:
-                print('You must either supply a PRT and session key on the command line or a file that contains them')
+                print(
+                    "You must either supply a PRT and session key on the command line or a file that contains them"
+                )
                 return
             print("Renewing PRT")
             prtdata = deviceauth.renew_prt()
             deviceauth.saveprt(prtdata, args.prt_file)
-    elif args.command == 'prtauth':
+    elif args.command == "prtauth":
         auth.set_user_agent(args.user_agent)
         if args.cae:
             auth.set_cae()
-        auth.set_client_id(args.client)
+
         auth.set_scope(args.scope)
         if args.redirect_url:
             redirect_url = args.redirect_url
         else:
-            redirect_url = find_redirurl_for_client(auth.client_id, interactive=False, broker=True)
+            redirect_url = find_redirurl_for_client(
+                auth.client_id, interactive=False, broker=True
+            )
         if args.tenant:
             auth.tenant = args.tenant
         if args.prt and args.prt_sessionkey:
@@ -1245,46 +2406,62 @@ def main():
         elif args.prt_file and deviceauth.loadprt(args.prt_file):
             pass
         else:
-            print('You must either supply a PRT and session key on the command line or a file that contains them')
+            print(
+                "You must either supply a PRT and session key on the command line or a file that contains them"
+            )
             return
         if args.prt_protocol_v3:
             if not args.scope and args.resource is not None:
                 args.scope = f"{args.resource}/.default"
-            tokendata = deviceauth.aad_brokerplugin_prt_auth_v3(args.client, args.scope, redirect_uri=redirect_url)
+            tokendata = deviceauth.aad_brokerplugin_prt_auth_v3(
+                args.client, args.scope, redirect_uri=redirect_url
+            )
         else:
-            tokendata = deviceauth.aad_brokerplugin_prt_auth(args.client, args.resource, redirect_uri=redirect_url)
+            tokendata = deviceauth.aad_brokerplugin_prt_auth(
+                args.client, args.resource, redirect_uri=redirect_url
+            )
         # We need to convert this to a token format roadlib understands
-        if 'access_token' in tokendata:
-            tokenobject, _ = auth.parse_accesstoken(tokendata['access_token'])
-            tokenobject['expiresIn'] = tokendata['expires_in']
-            tokenobject['refreshToken'] = tokendata['refresh_token']
+        if "access_token" in tokendata:
+            tokenobject, _ = auth.parse_accesstoken(tokendata["access_token"])
+            tokenobject["expiresIn"] = tokendata["expires_in"]
+            tokenobject["refreshToken"] = tokendata["refresh_token"]
             auth.outfile = args.tokenfile
             auth.tokendata = tokenobject
             auth.save_tokens(args)
         else:
-            print('No access token in token data, assuming custom request')
+            print("No access token in token data, assuming custom request")
             print(tokendata)
-    elif args.command in ('deviceauth', 'getdevicetoken', 'getdevicetokens'):
+    elif args.command in ("deviceauth", "getdevicetoken", "getdevicetokens"):
         auth.set_user_agent(args.user_agent)
-        if not deviceauth.loadcert(args.cert_pem, args.key_pem, args.cert_pfx, args.pfx_pass, args.pfx_base64):
+        if not deviceauth.loadcert(
+            args.cert_pem, args.key_pem, args.cert_pfx, args.pfx_pass, args.pfx_base64
+        ):
             return
         auth.set_user_agent(args.user_agent)
         if args.tenant:
             auth.tenant = args.tenant
-        tokenreply = deviceauth.get_token_for_device(args.client, args.resource, redirect_uri=args.redirect_url)
+        tokenreply = deviceauth.get_token_for_device(
+            args.client, args.resource, redirect_uri=args.redirect_url
+        )
         auth.outfile = args.tokenfile
         auth.tokendata = auth.tokenreply_to_tokendata(tokenreply)
         auth.save_tokens(args)
-    elif args.command == 'decrypt':
-        header, enc_key, iv, ciphertext, auth_tag = auth.parse_compact_jwe(args.data, args.verbose)
-        if header['alg'] == 'RSA-OAEP':
-            if not deviceauth.loadkey(args.key_pem, args.cert_pfx, args.pfx_pass, args.pfx_base64):
-                print('Data is encrypted with transport key but no such key could be loaded with the specified parameters')
+    elif args.command == "decrypt":
+        header, enc_key, iv, ciphertext, auth_tag = auth.parse_compact_jwe(
+            args.data, args.verbose
+        )
+        if header["alg"] == "RSA-OAEP":
+            if not deviceauth.loadkey(
+                args.key_pem, args.cert_pfx, args.pfx_pass, args.pfx_base64
+            ):
+                print(
+                    "Data is encrypted with transport key but no such key could be loaded with the specified parameters"
+                )
                 return
             decrypted = deviceauth.decrypt_jwe_with_transport_key(args.data)
-            print('Decrypted key (hex):')
-            print(binascii.hexlify(decrypted).decode('utf-8'))
-            print('Decrypted key plain:')
+            print("Decrypted key (hex):")
+            print(binascii.hexlify(decrypted).decode("utf-8"))
+            print("Decrypted key plain:")
             print(repr(decrypted))
         else:
             if args.prt_sessionkey:
@@ -1292,22 +2469,26 @@ def main():
             elif args.prt_file and deviceauth.loadprt(args.prt_file):
                 pass
             else:
-                print('You must either supply a session key on the command line or a file that contains them')
-                print('Data is encrypted with session key but no such key could be loaded with the specified parameters')
+                print(
+                    "You must either supply a session key on the command line or a file that contains them"
+                )
+                print(
+                    "Data is encrypted with session key but no such key could be loaded with the specified parameters"
+                )
                 return
             data = auth.decrypt_auth_response(args.data, deviceauth.session_key)
-            print('Decrypted data:')
+            print("Decrypted data:")
             print(repr(data))
             try:
                 parsed = json.loads(data)
-                print('Decrypted data (parsed)')
+                print("Decrypted data (parsed)")
                 print(json.dumps(parsed, sort_keys=True, indent=4))
             except (json.decoder.JSONDecodeError, UnicodeDecodeError):
-                print('Decrypted data (hex)')
+                print("Decrypted data (hex)")
                 print(binascii.hexlify(data))
 
-    elif args.command == 'codeauth':
-        auth.set_client_id(args.client)
+    elif args.command == "codeauth":
+
         auth.set_resource_uri(args.resource)
         auth.set_user_agent(args.user_agent)
         auth.tenant = args.tenant
@@ -1321,17 +2502,21 @@ def main():
         if args.scope:
             # Switch to identity platform v2 and use scope instead of resource
             auth.set_scope(args.scope)
-            auth.authenticate_with_code_native_v2(args.code, args.redirect_url, client_secret=args.password)
+            auth.authenticate_with_code_native_v2(
+                args.code, args.redirect_url, client_secret=args.password
+            )
         else:
-            auth.authenticate_with_code_native(args.code, args.redirect_url, client_secret=args.password)
+            auth.authenticate_with_code_native(
+                args.code, args.redirect_url, client_secret=args.password
+            )
         auth.outfile = args.tokenfile
         auth.save_tokens(args)
-    elif args.command == 'desktopsso':
-        auth.set_client_id(args.client)
+    elif args.command == "desktopsso":
+
         auth.set_resource_uri(args.resource)
         auth.set_user_agent(args.user_agent)
         auth.tenant = args.tenant
-        if args.krbtoken and args.krbtoken.lower() == 'stdin':
+        if args.krbtoken and args.krbtoken.lower() == "stdin":
             krbtoken = sys.stdin.read().strip()
         else:
             krbtoken = args.krbtoken
@@ -1340,23 +2525,23 @@ def main():
             auth.authenticate_with_desktopsso_token(dsso_code)
             auth.outfile = args.tokenfile
             auth.save_tokens(args)
-    elif args.command == 'listaliases':
-        print('Well-known clients. Can be used as alias with -c or --client')
+    elif args.command == "listaliases":
+        print("Well-known clients. Can be used as alias with -c or --client")
         print()
         for alias, clientid in WELLKNOWN_CLIENTS.items():
             print(f"{alias:<14} - {clientid}")
         print()
-        print('Well-known resources. Can be used as alias with -r or --resource')
+        print("Well-known resources. Can be used as alias with -r or --resource")
         print()
         for alias, resourceurl in WELLKNOWN_RESOURCES.items():
             print(f"{alias:<10} - {resourceurl}")
         print()
-        print('Well-known user agents. Can be used as alias with -ua or --user-agent')
+        print("Well-known user agents. Can be used as alias with -ua or --user-agent")
         print()
         for alias, useragent in WELLKNOWN_USER_AGENTS.items():
             print(f"{alias:<15} - {useragent}")
-    elif args.command == 'interactiveauth':
-        auth.set_client_id(args.client)
+    elif args.command == "interactiveauth":
+
         auth.set_resource_uri(args.resource)
         auth.set_user_agent(args.user_agent)
         auth.tenant = args.tenant
@@ -1375,36 +2560,70 @@ def main():
             redirect_url = args.redirect_url
         else:
             redirect_url = find_redirurl_for_client(auth.client_id, interactive=False)
-        selauth = SeleniumAuthentication(auth, deviceauth, redirect_url, proxy=args.proxy, proxy_type=args.proxy_type)
+        selauth = SeleniumAuthentication(
+            auth, deviceauth, redirect_url, proxy=args.proxy, proxy_type=args.proxy_type
+        )
         if args.url:
             url = args.url
         else:
-            url = auth.build_auth_url(redirect_url, 'code', args.scope)
+            url = auth.build_auth_url(redirect_url, "code", args.scope)
         service = selauth.get_service(args.driver_path)
         if not service:
             return
         selauth.driver = selauth.get_webdriver(service, intercept=True)
         if args.krbtoken:
-            if args.krbtoken.lower() == 'stdin':
+            if args.krbtoken.lower() == "stdin":
                 krbtoken = sys.stdin.read().strip()
             else:
                 krbtoken = args.krbtoken
-            result = selauth.selenium_login_with_kerberos(url, args.username, args.password, otpseed=args.otpseed, capture=args.capture_code, krbdata=krbtoken, keep=args.keep_open)
+            result = selauth.selenium_login_with_kerberos(
+                url,
+                args.username,
+                args.password,
+                otpseed=args.otpseed,
+                capture=args.capture_code,
+                krbdata=krbtoken,
+                keep=args.keep_open,
+            )
         elif args.estscookie:
-            result = selauth.selenium_login_with_estscookie(url, args.username, args.password, otpseed=args.otpseed, capture=args.capture_code, estscookie=args.estscookie, keep=args.keep_open)
+            result = selauth.selenium_login_with_estscookie(
+                url,
+                args.username,
+                args.password,
+                otpseed=args.otpseed,
+                capture=args.capture_code,
+                estscookie=args.estscookie,
+                keep=args.keep_open,
+            )
         elif custom_ua:
-            result = selauth.selenium_login_with_custom_useragent(url, args.username, args.password, otpseed=args.otpseed, capture=args.capture_code, federated=args.federated, keep=args.keep_open)
+            result = selauth.selenium_login_with_custom_useragent(
+                url,
+                args.username,
+                args.password,
+                otpseed=args.otpseed,
+                capture=args.capture_code,
+                federated=args.federated,
+                keep=args.keep_open,
+            )
         else:
-            result = selauth.selenium_login_regular(url, args.username, args.password, otpseed=args.otpseed, capture=args.capture_code, federated=args.federated, keep=args.keep_open)
+            result = selauth.selenium_login_regular(
+                url,
+                args.username,
+                args.password,
+                otpseed=args.otpseed,
+                capture=args.capture_code,
+                federated=args.federated,
+                keep=args.keep_open,
+            )
         if args.capture_code:
             if result:
-                print(f'Captured auth code: {result}')
+                print(f"Captured auth code: {result}")
             return
         elif result:
             auth.outfile = args.tokenfile
             auth.save_tokens(args)
-    elif args.command == 'clicodeauth':
-        auth.set_client_id(args.client)
+    elif args.command == "clicodeauth":
+
         auth.set_resource_uri(args.resource)
         auth.tenant = args.tenant
         auth.use_pkce = args.pkce
@@ -1420,32 +2639,34 @@ def main():
             redirect_url = args.redirect_url
         else:
             redirect_url = find_redirurl_for_client(auth.client_id, interactive=True)
-        url = auth.build_auth_url(redirect_url, 'code', args.scope)
-        print('Use the following URL in the external browser. Once authentication completes, paste the URL with a code query parameter back in the console here')
+        url = auth.build_auth_url(redirect_url, "code", args.scope)
+        print(
+            "Use the following URL in the external browser. Once authentication completes, paste the URL with a code query parameter back in the console here"
+        )
         print(f"\n{url}\n")
         code = None
         while True:
             try:
-                confirm = input(f'Enter the final URL or write quit to cancel: ')
+                confirm = input(f"Enter the final URL or write quit to cancel: ")
             except KeyboardInterrupt:
                 return
             answer = confirm.strip()
-            if answer.lower() in ('q', 'quit'):
+            if answer.lower() in ("q", "quit"):
                 return
             try:
                 parsed = urlparse(answer.strip())
             except:
-                print('Please paste a valid URL')
+                print("Please paste a valid URL")
                 continue
             params = parse_qs(parsed.query)
             try:
-                code = params['code'][0]
+                code = params["code"][0]
                 break
             except KeyError:
-                print('Please paste a valid URL containing a code query parameter')
+                print("Please paste a valid URL containing a code query parameter")
         if args.capture_code:
             if code:
-                print(f'Captured auth code: {code}')
+                print(f"Captured auth code: {code}")
             return
         elif code:
             if auth.scope:
@@ -1454,8 +2675,8 @@ def main():
                 auth.authenticate_with_code_native(code, redirect_url)
             auth.outfile = args.tokenfile
             auth.save_tokens(args)
-    elif args.command == 'keepassauth':
-        auth.set_client_id(args.client)
+    elif args.command == "keepassauth":
+
         auth.set_resource_uri(args.resource)
         auth.set_user_agent(args.user_agent)
         auth.tenant = args.tenant
@@ -1474,30 +2695,52 @@ def main():
             redirect_url = args.redirect_url
         else:
             redirect_url = find_redirurl_for_client(auth.client_id, interactive=False)
-        selauth = SeleniumAuthentication(auth, deviceauth, redirect_url, proxy=args.proxy, proxy_type=args.proxy_type)
-        password, otpseed = selauth.get_keepass_cred(args.username, args.keepass, args.keepass_password)
+        selauth = SeleniumAuthentication(
+            auth, deviceauth, redirect_url, proxy=args.proxy, proxy_type=args.proxy_type
+        )
+        password, otpseed = selauth.get_keepass_cred(
+            args.username, args.keepass, args.keepass_password
+        )
         if args.url:
             url = args.url
         else:
-            url = auth.build_auth_url(redirect_url, 'code', auth.scope)
+            url = auth.build_auth_url(redirect_url, "code", auth.scope)
         service = selauth.get_service(args.driver_path)
         if not service:
             return
         selauth.driver = selauth.get_webdriver(service, intercept=custom_ua)
         if custom_ua:
-            result = selauth.selenium_login_with_custom_useragent(url, args.username, password, otpseed, keep=args.keep_open, capture=args.capture_code, federated=args.federated, devicecode=args.device_code)
+            result = selauth.selenium_login_with_custom_useragent(
+                url,
+                args.username,
+                password,
+                otpseed,
+                keep=args.keep_open,
+                capture=args.capture_code,
+                federated=args.federated,
+                devicecode=args.device_code,
+            )
         else:
-            result = selauth.selenium_login_regular(url, args.username, password, otpseed, keep=args.keep_open, capture=args.capture_code, federated=args.federated, devicecode=args.device_code)
+            result = selauth.selenium_login_regular(
+                url,
+                args.username,
+                password,
+                otpseed,
+                keep=args.keep_open,
+                capture=args.capture_code,
+                federated=args.federated,
+                devicecode=args.device_code,
+            )
         if args.capture_code:
             if result:
-                print(f'Captured auth code: {result}')
+                print(f"Captured auth code: {result}")
             return
         if not result:
             return
         auth.outfile = args.tokenfile
         auth.save_tokens(args)
-    elif args.command == 'browserprtauth':
-        auth.set_client_id(args.client)
+    elif args.command == "browserprtauth":
+
         auth.set_resource_uri(args.resource)
         auth.set_user_agent(args.user_agent)
         auth.tenant = args.tenant
@@ -1516,32 +2759,45 @@ def main():
         elif args.prt_file and deviceauth.loadprt(args.prt_file):
             pass
         else:
-            print('You must either supply a PRT and session key on the command line or a file that contains them')
+            print(
+                "You must either supply a PRT and session key on the command line or a file that contains them"
+            )
             return
         if args.redirect_url:
             redirect_url = args.redirect_url
         else:
             redirect_url = find_redirurl_for_client(auth.client_id, interactive=False)
-        selauth = SeleniumAuthentication(auth, deviceauth, redirect_url, proxy=args.proxy, proxy_type=args.proxy_type)
+        selauth = SeleniumAuthentication(
+            auth, deviceauth, redirect_url, proxy=args.proxy, proxy_type=args.proxy_type
+        )
         if args.url:
             url = args.url
         else:
             if not args.tokens_stdout:
                 if args.scope:
-                    print(f'Running in token request mode - Requesting token with scope {auth.scope}\nIf you want a browser window instead, use the -url parameter to start browsing.')
+                    print(
+                        f"Running in token request mode - Requesting token with scope {auth.scope}\nIf you want a browser window instead, use the -url parameter to start browsing."
+                    )
                 else:
-                    print(f'Running in token request mode - Requesting token for {auth.resource_uri}\nIf you want a browser window instead, use the -url parameter to start browsing.')
-            url = auth.build_auth_url(redirect_url, 'code', args.scope)
+                    print(
+                        f"Running in token request mode - Requesting token for {auth.resource_uri}\nIf you want a browser window instead, use the -url parameter to start browsing."
+                    )
+            url = auth.build_auth_url(redirect_url, "code", args.scope)
         service = selauth.get_service(args.driver_path)
         if not service:
             return
         selauth.driver = selauth.get_webdriver(service, intercept=True)
-        result = selauth.selenium_login_with_prt(url, keep=args.keep_open, prtcookie=args.prt_cookie, capture=args.capture_code)
+        result = selauth.selenium_login_with_prt(
+            url,
+            keep=args.keep_open,
+            prtcookie=args.prt_cookie,
+            capture=args.capture_code,
+        )
         if not result and not args.keep_open:
             return
         if args.capture_code:
             if result:
-                print(f'Captured auth code: {result}')
+                print(f"Captured auth code: {result}")
             if not args.keep_open:
                 return
         else:
@@ -1553,8 +2809,8 @@ def main():
             except KeyboardInterrupt:
                 return
             return
-    elif args.command == 'browserprtinject':
-        auth.set_client_id(args.client)
+    elif args.command == "browserprtinject":
+
         auth.set_resource_uri(args.resource)
         auth.set_user_agent(args.user_agent)
         auth.tenant = args.tenant
@@ -1572,7 +2828,9 @@ def main():
         elif args.prt_file and deviceauth.loadprt(args.prt_file):
             pass
         else:
-            print('You must either supply a PRT and session key on the command line or a file that contains them')
+            print(
+                "You must either supply a PRT and session key on the command line or a file that contains them"
+            )
             return
         if args.redirect_url:
             redirect_url = args.redirect_url
@@ -1582,14 +2840,24 @@ def main():
         if args.url:
             url = args.url
         else:
-            url = auth.build_auth_url(redirect_url, 'code', args.scope)
+            url = auth.build_auth_url(redirect_url, "code", args.scope)
             if args.username:
-                url += '&login_hint=' + quote_plus(args.username)
+                url += "&login_hint=" + quote_plus(args.username)
             else:
-                url += '&prompt=select_account'
+                url += "&prompt=select_account"
 
-        if args.keepass and args.username and (args.keepass_password or 'KPPASS' in os.environ or args.keepass.endswith('.xml')):
-            password, otpseed = selauth.get_keepass_cred(args.username, args.keepass, args.keepass_password)
+        if (
+            args.keepass
+            and args.username
+            and (
+                args.keepass_password
+                or "KPPASS" in os.environ
+                or args.keepass.endswith(".xml")
+            )
+        ):
+            password, otpseed = selauth.get_keepass_cred(
+                args.username, args.keepass, args.keepass_password
+            )
         else:
             password = args.password
             otpseed = args.otpseed
@@ -1597,7 +2865,14 @@ def main():
         if not service:
             return
         selauth.driver = selauth.get_webdriver(service, intercept=True)
-        if not selauth.selenium_login_with_prt(url, identity=args.username, prtcookie=args.prt_cookie, password=password, otpseed=otpseed, keep=args.keep_open):
+        if not selauth.selenium_login_with_prt(
+            url,
+            identity=args.username,
+            prtcookie=args.prt_cookie,
+            password=password,
+            otpseed=otpseed,
+            keep=args.keep_open,
+        ):
             return
         auth.outfile = args.tokenfile
         auth.save_tokens(args)
@@ -1607,33 +2882,47 @@ def main():
             except KeyboardInterrupt:
                 return
             return
-    elif args.command == 'prtenrich':
+    elif args.command == "prtenrich":
         if not args.no_prt:
             if args.prt and args.prt_sessionkey:
                 deviceauth.setprt(args.prt, args.prt_sessionkey)
             elif args.prt_file and deviceauth.loadprt(args.prt_file):
                 pass
             else:
-                print('You must either supply a PRT and session key on the command line or a file that contains them')
+                print(
+                    "You must either supply a PRT and session key on the command line or a file that contains them"
+                )
                 return
-        auth.set_client_id('29d9ed98-a469-4536-ade2-f981bc1d605e')
+        auth.set_client_id("29d9ed98-a469-4536-ade2-f981bc1d605e")
         auth.set_user_agent(args.user_agent)
         if args.username:
-            hint = '&login_hint=' + quote_plus(args.username)
+            hint = "&login_hint=" + quote_plus(args.username)
         else:
-            hint = ''
+            hint = ""
         replyurl = "ms-appx-web://Microsoft.AAD.BrokerPlugin/DRS"
-        url = f'https://login.microsoftonline.com/common/oauth2/authorize?response_type=code&client_id=29d9ed98-a469-4536-ade2-f981bc1d605e&redirect_uri=ms-appx-web%3a%2f%2fMicrosoft.AAD.BrokerPlugin%2fDRS&resource=urn%3aaad%3atb%3aupdate%3aprt&add_account=noheadsup&scope=openid{hint}&response_mode=form_post&windows_api_version=2.0&amr_values=ngcmfa'
+        url = f"https://login.microsoftonline.com/common/oauth2/authorize?response_type=code&client_id=29d9ed98-a469-4536-ade2-f981bc1d605e&redirect_uri=ms-appx-web%3a%2f%2fMicrosoft.AAD.BrokerPlugin%2fDRS&resource=urn%3aaad%3atb%3aupdate%3aprt&add_account=noheadsup&scope=openid{hint}&response_mode=form_post&windows_api_version=2.0&amr_values=ngcmfa"
 
         if args.ngcmfa_drs_auth:
             # Get ngcmfa token for device registration service
-            auth.set_client_id('dd762716-544d-4aeb-a526-687b73838a22')
+            auth.set_client_id("dd762716-544d-4aeb-a526-687b73838a22")
             replyurl = "ms-appx-web://Microsoft.AAD.BrokerPlugin/dd762716-544d-4aeb-a526-687b73838a22"
-            url = f'https://login.microsoftonline.com/common/oauth2/authorize?response_type=code&client_id=dd762716-544d-4aeb-a526-687b73838a22&redirect_uri=ms-appx-web%3a%2f%2fMicrosoft.AAD.BrokerPlugin%2fdd762716-544d-4aeb-a526-687b73838a22&resource=urn%3ams-drs%3aenterpriseregistration.windows.net&add_account=noheadsup&scope=openid{hint}&response_mode=form_post&windows_api_version=2.0&amr_values=ngcmfa'
+            url = f"https://login.microsoftonline.com/common/oauth2/authorize?response_type=code&client_id=dd762716-544d-4aeb-a526-687b73838a22&redirect_uri=ms-appx-web%3a%2f%2fMicrosoft.AAD.BrokerPlugin%2fdd762716-544d-4aeb-a526-687b73838a22&resource=urn%3ams-drs%3aenterpriseregistration.windows.net&add_account=noheadsup&scope=openid{hint}&response_mode=form_post&windows_api_version=2.0&amr_values=ngcmfa"
 
-        selauth = SeleniumAuthentication(auth, deviceauth, replyurl, proxy=args.proxy, proxy_type=args.proxy_type)
-        if args.username and args.keepass and (args.keepass_password or 'KPPASS' in os.environ or args.keepass.endswith('.xml')):
-            _, otpseed = selauth.get_keepass_cred(args.username, args.keepass, args.keepass_password)
+        selauth = SeleniumAuthentication(
+            auth, deviceauth, replyurl, proxy=args.proxy, proxy_type=args.proxy_type
+        )
+        if (
+            args.username
+            and args.keepass
+            and (
+                args.keepass_password
+                or "KPPASS" in os.environ
+                or args.keepass.endswith(".xml")
+            )
+        ):
+            _, otpseed = selauth.get_keepass_cred(
+                args.username, args.keepass, args.keepass_password
+            )
         else:
             otpseed = args.otpseed
         service = selauth.get_service(args.driver_path)
@@ -1647,26 +2936,38 @@ def main():
             auth.outfile = args.tokenfile
             auth.save_tokens(args)
         else:
-            if tokenreply and tokenreply['refresh_token']:
-                print('Got refresh token. Can be used to request prt with roadtx prt -r <refreshtoken>')
-                print(tokenreply['refresh_token'])
+            if tokenreply and tokenreply["refresh_token"]:
+                print(
+                    "Got refresh token. Can be used to request prt with roadtx prt -r <refreshtoken>"
+                )
+                print(tokenreply["refresh_token"])
             else:
-                print('No tokendata found. Something probably went wrong')
+                print("No tokendata found. Something probably went wrong")
 
-    elif args.command == 'getotp':
+    elif args.command == "getotp":
         selauth = SeleniumAuthentication(auth, deviceauth, None)
-        if args.keepass and args.username and (args.keepass_password or 'KPPASS' in os.environ or args.keepass.endswith('.xml')):
-            _, otpseed = selauth.get_keepass_cred(args.username, args.keepass, args.keepass_password)
+        if (
+            args.keepass
+            and args.username
+            and (
+                args.keepass_password
+                or "KPPASS" in os.environ
+                or args.keepass.endswith(".xml")
+            )
+        ):
+            _, otpseed = selauth.get_keepass_cred(
+                args.username, args.keepass, args.keepass_password
+            )
         else:
             otpseed = args.otpseed
 
         if not otpseed:
-            print('Please use --otpseed or supply a keepass file containing otp data')
+            print("Please use --otpseed or supply a keepass file containing otp data")
             return
         otp = pyotp.TOTP(otpseed)
         now = str(otp.now())
-        print(f'OTP value: {now}')
-    elif args.command == 'describe':
+        print(f"OTP value: {now}")
+    elif args.command == "describe":
         tokendata = None
         # Explicitly set token option
         if args.token is not None:
@@ -1684,32 +2985,36 @@ def main():
             # Describing saved token file args.tokenfile
             if os.path.exists(args.tokenfile):
                 if args.verbose:
-                    print("[debug] Reading token value from file '%s'." % (args.tokenfile))
+                    print(
+                        "[debug] Reading token value from file '%s'." % (args.tokenfile)
+                    )
                 f = open(args.tokenfile, "r")
                 tokendata = f.read()
                 f.close()
-        if tokendata[0] == '{':
+        if tokendata[0] == "{":
             # assume json object
             tokenobject = json.loads(tokendata)
             try:
-                tokendata = tokenobject['accessToken']
+                tokendata = tokenobject["accessToken"]
             except KeyError:
                 try:
-                    tokendata = tokenobject['access_token']
+                    tokendata = tokenobject["access_token"]
                 except KeyError:
-                    print('Unrecognized input format')
+                    print("Unrecognized input format")
                     return
-        if tokendata[0:2] == '0.':
-            print('The supplied data looks like an encrypted token or nonce, nothing to decode here!')
+        if tokendata[0:2] == "0.":
+            print(
+                "The supplied data looks like an encrypted token or nonce, nothing to decode here!"
+            )
             return
         header, body, signature = auth.parse_jwt(tokendata)
         print(json.dumps(header, sort_keys=True, indent=4))
         print(json.dumps(body, sort_keys=True, indent=4))
-    elif args.command in ('getscope', 'findscope'):
+    elif args.command in ("getscope", "findscope"):
         # Load scope data
         current_dir = os.path.abspath(os.path.dirname(__file__))
-        datafile = os.path.join(current_dir, 'firstpartyscopes.json')
-        with codecs.open(datafile,'r','utf-8') as infile:
+        datafile = os.path.join(current_dir, "firstpartyscopes.json")
+        with codecs.open(datafile, "r", "utf-8") as infile:
             data = json.load(infile)
         if not args.scope and not args.all:
             getscope_parser.print_help()
@@ -1720,19 +3025,19 @@ def main():
             results = set()
 
             app_resource_ids = defaultdict(set)
-            for resource, app_id in data['resourceidentifiers'].items():
+            for resource, app_id in data["resourceidentifiers"].items():
                 app_resource_ids[app_id].add(resource)
 
-            for app in data['apps'].values():
-                if args.foci and not app['foci']:
+            for app in data["apps"].values():
+                if args.foci and not app["foci"]:
                     continue
-                if not app['public_client'] and not args.all_clients:
+                if not app["public_client"] and not args.all_clients:
                     continue
-                for app_id, scopes in app['scopes'].items():
-                    for resource in app_resource_ids.get(app_id, [f'https://{app_id}']):
-                        resource = resource.rstrip('/')
+                for app_id, scopes in app["scopes"].items():
+                    for resource in app_resource_ids.get(app_id, [f"https://{app_id}"]):
+                        resource = resource.rstrip("/")
                         for scope in map(str.lower, scopes):
-                            results.add(f'{resource}/{scope}')
+                            results.add(f"{resource}/{scope}")
 
             if args.csv:
                 print('"scope"')
@@ -1745,78 +3050,86 @@ def main():
             return
 
         try:
-            resource, scope = args.scope.lower().rsplit('/', 1)
+            resource, scope = args.scope.lower().rsplit("/", 1)
         except ValueError:
             print("No resource (API) specified in scope, defaulting to Microsoft Graph")
             resource = "https://graph.microsoft.com"
             scope = args.scope.lower()
 
         try:
-            resourceid = data['resourceidentifiers'][resource.lower()]
+            resourceid = data["resourceidentifiers"][resource.lower()]
         except KeyError:
             try:
-                resourceid = data['resourceidentifiers'][resource.lower() + '/']
+                resourceid = data["resourceidentifiers"][resource.lower() + "/"]
             except KeyError:
-                print(f'The API {resource} is not a known resource')
+                print(f"The API {resource} is not a known resource")
                 return
 
         # Loop through scopes
         results = []
-        for appid, app in data['apps'].items():
+        for appid, app in data["apps"].items():
             # Skip non-foci apps
-            if args.foci and not app['foci']:
+            if args.foci and not app["foci"]:
                 continue
             # Skip non-public clients by default since we can't easily auth to them
-            if not app['public_client'] and not args.all_clients:
+            if not app["public_client"] and not args.all_clients:
                 continue
             try:
-                scopes = app['scopes'][resourceid]
+                scopes = app["scopes"][resourceid]
                 if len([s for s in scopes if s.lower() == scope]) == 0:
                     continue
             except KeyError:
                 # Not on this app
                 continue
             results.append((appid, app))
-        appid = 'App (client) ID'
-        name = 'App name'
-        scopes = 'Scope on this resource'
+        appid = "App (client) ID"
+        name = "App name"
+        scopes = "Scope on this resource"
         if len(results) == 0:
             print("No apps found!")
             return
         if args.csv:
             print("App ID,App Name,FOCI,Scopes")
             for appid, app in results:
-                scopes = ' '.join(app['scopes'][resourceid])
-                foci = 'Yes' if app['foci'] else 'No'
-                name = app['name'].replace('"',r'\"')
+                scopes = " ".join(app["scopes"][resourceid])
+                foci = "Yes" if app["foci"] else "No"
+                name = app["name"].replace('"', r"\"")
                 print(f'"{appid}","{name}","{foci}","{scopes}"')
         else:
             print(f"{appid:<40} {name:<40} Foci?   {scopes}")
             for appid, app in results:
-                scopes = ' '.join(app['scopes'][resourceid])
-                foci = 'Yes' if app['foci'] else 'No'
+                scopes = " ".join(app["scopes"][resourceid])
+                foci = "Yes" if app["foci"] else "No"
                 print(f"{appid:<40} {app['name']:<40} {foci:<7} {scopes}")
-    elif args.command == 'winhello':
+    elif args.command == "winhello":
         auth.set_user_agent(args.user_agent)
         if args.access_token:
             tokenobject, tokendata = auth.parse_accesstoken(args.access_token)
         else:
             try:
-                with codecs.open('.roadtools_auth', 'r', 'utf-8') as infile:
+                with codecs.open(".roadtools_auth", "r", "utf-8") as infile:
                     tokenobject = json.load(infile)
-                _, tokendata = auth.parse_accesstoken(tokenobject['accessToken'])
+                _, tokendata = auth.parse_accesstoken(tokenobject["accessToken"])
             except FileNotFoundError:
-                print('No auth data found. Ether supply an access token with --access-token or make sure a token is present on disk in .roadtools_auth')
+                print(
+                    "No auth data found. Ether supply an access token with --access-token or make sure a token is present on disk in .roadtools_auth"
+                )
                 return
-        if tokendata['aud'] != 'urn:ms-drs:enterpriseregistration.windows.net':
-            print(f"Wrong token audience, got {tokendata['aud']} but expected: urn:ms-drs:enterpriseregistration.windows.net")
-            print("Make sure to request a token with -r urn:ms-drs:enterpriseregistration.windows.net")
+        if tokendata["aud"] != "urn:ms-drs:enterpriseregistration.windows.net":
+            print(
+                f"Wrong token audience, got {tokendata['aud']} but expected: urn:ms-drs:enterpriseregistration.windows.net"
+            )
+            print(
+                "Make sure to request a token with -r urn:ms-drs:enterpriseregistration.windows.net"
+            )
             return
         key, pubkeycngblob = deviceauth.create_hello_key(args.key_pem)
-        result = deviceauth.register_winhello_key(pubkeycngblob, tokenobject['accessToken'])
+        result = deviceauth.register_winhello_key(
+            pubkeycngblob, tokenobject["accessToken"]
+        )
         print(result)
 
-    elif args.command == 'genhellokey':
+    elif args.command == "genhellokey":
         key, pubkeycngblob = deviceauth.create_hello_key(args.key_pem)
         if not args.device_id:
             deviceid = "d22a8b4b-d138-4271-a677-de4208305cb3"
@@ -1825,111 +3138,145 @@ def main():
         data = {
             "usage": "NGC",
             "keyIdentifier": deviceauth.get_privkey_kid(key),
-            "keyMaterial": pubkeycngblob.decode('utf-8'),
+            "keyMaterial": pubkeycngblob.decode("utf-8"),
             "creationTime": "2022-10-12T18:29:51.3793062Z",
             "deviceId": deviceid,
             "customKeyInformation": "AQAAAAACAAAAAAAAAAAA",
             "fidoAaGuid": None,
             "fidoAuthenticatorVersion": None,
-            "fidoAttestationCertificates": []
+            "fidoAttestationCertificates": [],
         }
         print(json.dumps(data, sort_keys=True, indent=4))
-    elif args.command == 'bulkenrollmenttoken':
-        if args.action == 'request':
+    elif args.command == "bulkenrollmenttoken":
+        if args.action == "request":
             if args.access_token:
                 tokenobject, tokendata = auth.parse_accesstoken(args.access_token)
             else:
                 try:
-                    with codecs.open(args.tokenfile, 'r', 'utf-8') as infile:
+                    with codecs.open(args.tokenfile, "r", "utf-8") as infile:
                         tokenobject = json.load(infile)
-                    _, tokendata = auth.parse_accesstoken(tokenobject['accessToken'])
+                    _, tokendata = auth.parse_accesstoken(tokenobject["accessToken"])
                 except FileNotFoundError:
-                    print('No auth data found. Ether supply an access token with --access-token or make sure a token is present on disk in .roadtools_auth')
+                    print(
+                        "No auth data found. Ether supply an access token with --access-token or make sure a token is present on disk in .roadtools_auth"
+                    )
                     return
-            if tokendata['aud'] != 'urn:ms-drs:enterpriseregistration.windows.net':
-                print(f"Wrong token audience, got {tokendata['aud']} but expected: urn:ms-drs:enterpriseregistration.windows.net")
-                print("Make sure to request a token with -r urn:ms-drs:enterpriseregistration.windows.net")
+            if tokendata["aud"] != "urn:ms-drs:enterpriseregistration.windows.net":
+                print(
+                    f"Wrong token audience, got {tokendata['aud']} but expected: urn:ms-drs:enterpriseregistration.windows.net"
+                )
+                print(
+                    "Make sure to request a token with -r urn:ms-drs:enterpriseregistration.windows.net"
+                )
                 return
-            result = auth.get_bulk_enrollment_token(access_token=tokenobject['accessToken'])
+            result = auth.get_bulk_enrollment_token(
+                access_token=tokenobject["accessToken"]
+            )
             if result:
                 auth.outfile = args.bulktokenfile
                 auth.save_tokens(args)
         else:
             # Use token
-            auth.set_client_id('b90d5b8f-5503-4153-b545-b31cecfaece2')
-            auth.set_resource_uri('drs')
+            auth.set_client_id("b90d5b8f-5503-4153-b545-b31cecfaece2")
+            auth.set_resource_uri("drs")
             try:
-                with codecs.open(args.bulktokenfile, 'r', 'utf-8') as infile:
+                with codecs.open(args.bulktokenfile, "r", "utf-8") as infile:
                     tokenobject = json.load(infile)
-                _, tokendata = auth.parse_accesstoken(tokenobject['accessToken'])
+                _, tokendata = auth.parse_accesstoken(tokenobject["accessToken"])
             except FileNotFoundError:
-                print('No auth data found. Make sure the bulk enrollment token is present on disk in the file specified in --bulktokenfile')
+                print(
+                    "No auth data found. Make sure the bulk enrollment token is present on disk in the file specified in --bulktokenfile"
+                )
                 return
-            result = auth.authenticate_with_refresh_native(tokenobject['refreshToken'])
+            result = auth.authenticate_with_refresh_native(tokenobject["refreshToken"])
             if result:
                 auth.outfile = args.tokenfile
                 auth.save_tokens(args)
 
-    elif args.command == 'decryptadfskey':
+    elif args.command == "decryptadfskey":
         rawblob = base64.b64decode(args.encryptedpfx)
-        rawkey = binascii.unhexlify(args.key.replace('-',''))
+        rawkey = binascii.unhexlify(args.key.replace("-", ""))
         pfx = EncryptedPFX(rawblob, rawkey, args.verbose)
         decrypted_pfx = pfx.decrypt_pfx()
-        if args.output_format == 'pfx':
+        if args.output_format == "pfx":
             pfx.save_pfx(decrypted_pfx, args.cert_pfx)
-            print(f'Saved decrypted key to {args.cert_pfx}')
+            print(f"Saved decrypted key to {args.cert_pfx}")
         else:
             pfx.save_pem(decrypted_pfx, args.cert_pem, args.key_pem)
-            print(f'Saved decrypted certificate to {args.cert_pem} and key to {args.key_pem}')
-    elif args.command == 'samltoken':
+            print(
+                f"Saved decrypted certificate to {args.cert_pem} and key to {args.key_pem}"
+            )
+    elif args.command == "samltoken":
         signer = SAMLSigner()
-        if not signer.loadcert(args.cert_pem, args.key_pem, args.cert_pfx, args.pfx_pass, args.pfx_base64):
+        if not signer.loadcert(
+            args.cert_pem, args.key_pem, args.cert_pfx, args.pfx_pass, args.pfx_base64
+        ):
             sys.exit(1)
         if not args.unique_id and not args.guid:
-            print('Either the unique-id or guid of the user to spoof is required')
+            print("Either the unique-id or guid of the user to spoof is required")
             sys.exit(1)
         elif args.unique_id:
             uid = args.unique_id
         else:
             uid = encode_object_guid(args.guid)
-        template, assertionid = signer.format_template(uid, args.upn, args.issuer, args.mfa)
+        template, assertionid = signer.format_template(
+            uid, args.upn, args.issuer, args.mfa
+        )
         signed = signer.sign_xml(template, assertionid)
-        print(signed.decode('utf-8'))
-    elif args.command == 'prtcookie':
+        print(signed.decode("utf-8"))
+    elif args.command == "prtcookie":
         if args.prt and args.prt_sessionkey:
             deviceauth.setprt(args.prt, args.prt_sessionkey)
         elif args.prt_file and deviceauth.loadprt(args.prt_file):
             pass
         else:
-            print('You must either supply a PRT and session key on the command line or a file that contains them')
+            print(
+                "You must either supply a PRT and session key on the command line or a file that contains them"
+            )
             return
-        challenge = auth.get_srv_challenge()['Nonce']
-        cookie = auth.create_prt_cookie_kdf_ver_2(deviceauth.prt, deviceauth.session_key, challenge)
+        challenge = auth.get_srv_challenge()["Nonce"]
+        cookie = auth.create_prt_cookie_kdf_ver_2(
+            deviceauth.prt, deviceauth.session_key, challenge
+        )
         print(f"PRT cookie: {cookie}")
-        print("Can be used in external browsers using the x-ms-RefreshTokenCredential header or cookie. Note that a PRT cookie is only valid for 5 minutes.")
-    elif args.command == 'owalogin':
+        print(
+            "Can be used in external browsers using the x-ms-RefreshTokenCredential header or cookie. Note that a PRT cookie is only valid for 5 minutes."
+        )
+    elif args.command == "owalogin":
         auth.set_user_agent(args.user_agent)
         if args.access_token:
             tokenobject, tokendata = auth.parse_accesstoken(args.access_token)
         else:
             try:
-                with codecs.open(args.tokenfile, 'r', 'utf-8') as infile:
+                with codecs.open(args.tokenfile, "r", "utf-8") as infile:
                     tokenobject = json.load(infile)
-                _, tokendata = auth.parse_accesstoken(tokenobject['accessToken'])
+                _, tokendata = auth.parse_accesstoken(tokenobject["accessToken"])
             except FileNotFoundError:
-                print('No auth data found. Ether supply an access token with --access-token or make sure a token is present on disk in .roadtools_auth')
+                print(
+                    "No auth data found. Ether supply an access token with --access-token or make sure a token is present on disk in .roadtools_auth"
+                )
                 return
-        if tokendata['aud'] not in ['https://outlook.office.com','https://outlook.office365.com','https://outlook.office.com/','00000002-0000-0ff1-ce00-000000000000','https://outlook.office365.com/']:
-            print(f"Wrong token audience, got {tokendata['aud']} but expected: https://outlook.office.com")
+        if tokendata["aud"] not in [
+            "https://outlook.office.com",
+            "https://outlook.office365.com",
+            "https://outlook.office.com/",
+            "00000002-0000-0ff1-ce00-000000000000",
+            "https://outlook.office365.com/",
+        ]:
+            print(
+                f"Wrong token audience, got {tokendata['aud']} but expected: https://outlook.office.com"
+            )
             print("Make sure to request a token with -r https://outlook.office.com")
             return
         auth.set_user_agent(args.user_agent)
-        selauth = SeleniumAuthentication(auth, deviceauth, None, proxy=args.proxy, proxy_type=args.proxy_type)
+        selauth = SeleniumAuthentication(
+            auth, deviceauth, None, proxy=args.proxy, proxy_type=args.proxy_type
+        )
         service = selauth.get_service(None)
         if not service:
             return
         selauth.driver = selauth.get_webdriver(service, intercept=True)
-        res = selauth.selenium_login_owatoken(tokenobject['accessToken'])
+        res = selauth.selenium_login_owatoken(tokenobject["accessToken"])
         if res is False:
             return
         try:
@@ -1937,36 +3284,48 @@ def main():
         except KeyboardInterrupt:
             return
         return
-    elif args.command == 'sharepointlogin':
+    elif args.command == "sharepointlogin":
         auth.set_user_agent(args.user_agent)
         if args.access_token:
             tokenobject, tokendata = auth.parse_accesstoken(args.access_token)
         else:
             try:
-                with codecs.open(args.tokenfile, 'r', 'utf-8') as infile:
+                with codecs.open(args.tokenfile, "r", "utf-8") as infile:
                     tokenobject = json.load(infile)
-                _, tokendata = auth.parse_accesstoken(tokenobject['accessToken'])
+                _, tokendata = auth.parse_accesstoken(tokenobject["accessToken"])
             except FileNotFoundError:
-                print('No auth data found. Ether supply an access token with --access-token or make sure a token is present on disk in .roadtools_auth')
+                print(
+                    "No auth data found. Ether supply an access token with --access-token or make sure a token is present on disk in .roadtools_auth"
+                )
                 return
-        if tokendata['aud'] == '00000003-0000-0ff1-ce00-000000000000' and not args.host:
-            print('You must specify the SharePoint host to use with this token. Example --host https://company-my.sharepoint.com')
+        if tokendata["aud"] == "00000003-0000-0ff1-ce00-000000000000" and not args.host:
+            print(
+                "You must specify the SharePoint host to use with this token. Example --host https://company-my.sharepoint.com"
+            )
             return
-        if tokendata['aud'] != '00000003-0000-0ff1-ce00-000000000000' and not tokendata['aud'].endswith('sharepoint.com'):
-            print(f"Wrong token audience, got {tokendata['aud']} but expected an audience ending with sharepoint.com")
-            print("Make sure to request a token with -r https://mycompany-my.sharepoint.com")
+        if tokendata["aud"] != "00000003-0000-0ff1-ce00-000000000000" and not tokendata[
+            "aud"
+        ].endswith("sharepoint.com"):
+            print(
+                f"Wrong token audience, got {tokendata['aud']} but expected an audience ending with sharepoint.com"
+            )
+            print(
+                "Make sure to request a token with -r https://mycompany-my.sharepoint.com"
+            )
             return
         auth.set_user_agent(args.user_agent)
-        selauth = SeleniumAuthentication(auth, deviceauth, None, proxy=args.proxy, proxy_type=args.proxy_type)
+        selauth = SeleniumAuthentication(
+            auth, deviceauth, None, proxy=args.proxy, proxy_type=args.proxy_type
+        )
         service = selauth.get_service(None)
         if not service:
             return
         selauth.driver = selauth.get_webdriver(service, intercept=True)
         if args.host:
-            spohost = args.host.rstrip('/')
+            spohost = args.host.rstrip("/")
         else:
-            spohost = tokendata['aud']
-        res = selauth.selenium_login_spotoken(tokenobject['accessToken'], spohost)
+            spohost = tokendata["aud"]
+        res = selauth.selenium_login_spotoken(tokenobject["accessToken"], spohost)
         if res is False:
             return
         try:
@@ -1975,5 +3334,6 @@ def main():
             return
         return
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/roadtx/roadtools/roadtx/main.py
+++ b/roadtx/roadtools/roadtx/main.py
@@ -2000,7 +2000,7 @@ def main():
 
     args = parser.parse_args()
 
-    if args.client is not None:
+    if hasattr(args, "client") and args.client is not None:
         auth.set_client_id(args.client)
         enrich_args_from_firstparty(auth.client_id, args)
 

--- a/roadtx/roadtools/roadtx/utils.py
+++ b/roadtx/roadtools/roadtx/utils.py
@@ -1,28 +1,58 @@
 import os
 import codecs
 import json
+
+
 def find_redirurl_for_client(client, interactive=True, broker=False):
-    '''
+    """
     Get valid redirect URLs for specified client. Interactive means a https URL is preferred.
     In practice roadtx often prefers non-interactive URLs even with interactive flows since it rewrites
     the URLs on the fly anyway
-    '''
+    """
     current_dir = os.path.abspath(os.path.dirname(__file__))
-    datafile = os.path.join(current_dir, 'firstpartyscopes.json')
-    with codecs.open(datafile,'r','utf-8') as infile:
+    datafile = os.path.join(current_dir, "firstpartyscopes.json")
+    with codecs.open(datafile, "r", "utf-8") as infile:
         data = json.load(infile)
     try:
-        app = data['apps'][client.lower()]
+        app = data["apps"][client.lower()]
     except KeyError:
-        return 'https://login.microsoftonline.com/common/oauth2/nativeclient'
+        return "https://login.microsoftonline.com/common/oauth2/nativeclient"
     if broker:
-        brokerurl = f'ms-appx-web://Microsoft.AAD.BrokerPlugin/{client.lower()}'
-        if brokerurl in app['redirect_uris']:
+        brokerurl = f"ms-appx-web://Microsoft.AAD.BrokerPlugin/{client.lower()}"
+        if brokerurl in app["redirect_uris"]:
             return brokerurl
-        return app['preferred_noninteractive_redirurl']
-    if interactive and app['preferred_interactive_redirurl'] is not None:
-        return app['preferred_interactive_redirurl']
-    if app['preferred_noninteractive_redirurl']:
-        return app['preferred_noninteractive_redirurl']
+        return app["preferred_noninteractive_redirurl"]
+    if interactive and app["preferred_interactive_redirurl"] is not None:
+        return app["preferred_interactive_redirurl"]
+    if app["preferred_noninteractive_redirurl"]:
+        return app["preferred_noninteractive_redirurl"]
     # Return default URL even if it might not work since some follow up functions break when called with a None value
-    return 'https://login.microsoftonline.com/common/oauth2/nativeclient'
+    return "https://login.microsoftonline.com/common/oauth2/nativeclient"
+
+
+def enrich_args_from_firstparty(client_id: str, args):
+    """
+    Modifies args object in-place using metadata from firstpartyscopes.json if present.
+    """
+    if not client_id:
+        return
+
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    datafile = os.path.join(current_dir, "firstpartyscopes.json")
+    with codecs.open(datafile, "r", "utf-8") as infile:
+        data = json.load(infile)
+
+    client_id = client_id.lower()
+
+    app = data.get("apps", {}).get(client_id)
+    if not app:
+        return
+
+    if not getattr(args, "origin", None) and "origin" in app:
+        args.origin = app["origin"]
+
+    if not getattr(args, "scope", None) and "default_scope" in app:
+        args.scope = app["default_scope"]
+
+    if not getattr(args, "pkce", False) and app.get("requires_pkce", False):
+        args.pkce = True


### PR DESCRIPTION
Hello @dirkjanm 👋

I have recently used `roadtx` during an engagement to retrieve a JWT from [Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer), which proved incredibly useful for performing post-exploitation actions using Microsoft Graph. To achieve this, I initially used:

```shell
roadtx browserprtauth --origin "https://developer.microsoft.com" --redirect-url "https://developer.microsoft.com/en-us/graph/graph-explorer" --client "de8bc8b5-d9f9-48b1-a8ad-b748da725064" --scope "https://graph.microsoft.com/.default" --pkce --prt-cookie  <x-ms-RefreshTokenCredential>
```

To simplify this workflow and make Graph Explorer more accessible within roadtx, I’ve added the following entry to `firstpartyscopes.json`:
```json
"de8bc8b5-d9f9-48b1-a8ad-b748da725064": {
    "name": "Graph Explorer",
    "public_client": true,
    "foci": false,
    "preferred_interactive_redirurl": "https://developer.microsoft.com/en-us/graph/graph-explorer",
    "preferred_noninteractive_redirurl": "https://developer.microsoft.com/en-us/graph/graph-explorer",
    "redirect_uris": [
        "https://developer.microsoft.com/en-us/graph/graph-explorer"
    ],
    "origin": "https://developer.microsoft.com",
    "default_scope": "https://graph.microsoft.com/.default",
    "requires_pkce": true
},
```

With this addition, it's now possible to use the much simpler:

```shell
roadtx interactiveauth --client graph
```

Once authenticated, users can seamlessly interact with Microsoft Graph APIs, for example to send an email:
```shell
curl -X POST https://graph.microsoft.com/v1.0/me/sendMail \
  -H "Authorization: Bearer $(jq -r '.accessToken' .roadtools_auth)" -H "Content-Type: application/json" \ 
  --data-raw '{
    "message": {
      "subject": "[Graph Explorer] Test email",
      "body": {
        "contentType": "Text",
        "content": "Test email from Graph API via curl."
      },
      "toRecipients": [
        {
          "emailAddress": {
            "address": "graphexplorer@yopmail.com"
          }
        }
      ]
    },
    "saveToSentItems": "true"
  }'
```

I hope this contribution proves useful!

Also, please note that the linter reformatted some arguments in main.py. I’d recommend keeping those changes, as they improve readability and align with modern Python conventions for maintainability.

Warm regards,