### PR TITLE
Catch additional requests.exception.JSONDecodeError.

### DIFF
--- a/roadtx/roadtools/roadtx/main.py
+++ b/roadtx/roadtools/roadtx/main.py
@@ -16,6 +16,7 @@ from roadtools.roadtx.selenium import SeleniumAuthentication
 from roadtools.roadtx.utils import find_redirurl_for_client, parse_encrypted_token
 from roadtools.roadtx.federation import EncryptedPFX, SAMLSigner, encode_object_guid
 import pyotp
+import requests
 
 RR_HELP = 'ROADtools Token eXchange by Dirk-jan Mollema (@_dirkjan) / Outsider Security (outsidersecurity.nl)'
 
@@ -2218,7 +2219,7 @@ def main():
             print(response.status_code)
         try:
             print(json.dumps(response.json(), indent=4))
-        except json.decoder.JSONDecodeError:
+        except (requests.exceptions.JSONDecodeError, json.decoder.JSONDecodeError):
             print(response.text)
 
 if __name__ == '__main__':


### PR DESCRIPTION
In case the response body does not contain valid json, a requst.exception.JSONDecodeError is raised. This could happen if the content of a non-json file on OneDrive is requested, e.g.,

$ roadtx graphrequest https://graph.microsoft.com/v1.0/me/drive/items/01TMQUY7KN2C22NINHHRG33DE7AVZA7ADL {
...
    "file": {
...
        "mimeType": "text/plain"
    },
...
}
$ roadtx graphrequest https://graph.microsoft.com/v1.0/me/drive/items/01TMQUY7KN2C22NINHHRG33DE7AVZA7ADL/content