### PR TITLE
Add custom HTTP headers support to authentication flows

### DIFF
--- a/roadlib/roadtools/roadlib/auth.py
+++ b/roadlib/roadtools/roadlib/auth.py
@@ -66,6 +66,7 @@ class Authentication():
         self.claims = None
         self.use_pkce = False
         self.pkce_secret = None
+        self.custom_headers = {}
 
         # For cert based app auth
         self.appprivkey = None
@@ -116,6 +117,7 @@ class Authentication():
         """
         self.user_agent = self.lookup_user_agent(useragent)
 
+<<<<<<< Updated upstream
     def get_redirect_for_client(self, client_id, interactive=False, broker=False):
         """
         Try to resolve a valid redirect URI for a client, using roadtx lookup if available.
@@ -126,6 +128,14 @@ class Authentication():
             return utils.find_redirurl_for_client(client_id, interactive=interactive, broker=broker)
         except Exception:
             return 'https://login.microsoftonline.com/common/oauth2/nativeclient'
+=======
+    def set_custom_headers(self, headers_dict):
+        """
+        Sets custom headers to include in all HTTP requests
+        """
+        if headers_dict:
+            self.custom_headers = headers_dict
+>>>>>>> Stashed changes
 
     def user_discovery_v1(self, username):
         """
@@ -1595,6 +1605,9 @@ class Authentication():
         auth_parser.add_argument('--tokens-stdout',
                                  action='store_true',
                                  help='Do not store tokens on disk, pipe to stdout instead')
+        auth_parser.add_argument('--headers',
+                                 action='store',
+                                 help='Custom headers in JSON format, e.g., \'{"X-AnchorMailbox": "Oid:objectid@tenantid"}\'')
         auth_parser.add_argument('--debug',
                                  action='store_true',
                                  help='Enable debug logging to disk')
@@ -1801,6 +1814,10 @@ class Authentication():
             headers = kwargs.get('headers',{})
             headers['User-Agent'] = self.user_agent
             kwargs['headers'] = headers
+        if self.custom_headers:
+            headers = kwargs.get('headers',{})
+            headers.update(self.custom_headers)
+            kwargs['headers'] = headers
         return requests.get(*args, timeout=30.0, **kwargs)
 
     def requests_post(self, *args, **kwargs):
@@ -1816,6 +1833,10 @@ class Authentication():
         if self.origin:
             headers = kwargs.get('headers',{})
             headers['Origin'] = self.origin
+            kwargs['headers'] = headers
+        if self.custom_headers:
+            headers = kwargs.get('headers',{})
+            headers.update(self.custom_headers)
             kwargs['headers'] = headers
         return requests.post(*args, timeout=30.0, **kwargs)
 
@@ -1833,6 +1854,10 @@ class Authentication():
             headers = kwargs.get('headers',{})
             headers['Origin'] = self.origin
             kwargs['headers'] = headers
+        if self.custom_headers:
+            headers = kwargs.get('headers',{})
+            headers.update(self.custom_headers)
+            kwargs['headers'] = headers
         return requests.put(*args, timeout=30.0, **kwargs)
 
     def requests_patch(self, *args, **kwargs):
@@ -1849,6 +1874,10 @@ class Authentication():
             headers = kwargs.get('headers',{})
             headers['Origin'] = self.origin
             kwargs['headers'] = headers
+        if self.custom_headers:
+            headers = kwargs.get('headers',{})
+            headers.update(self.custom_headers)
+            kwargs['headers'] = headers
         return requests.patch(*args, timeout=30.0, **kwargs)
     
     def requests_delete(self, *args, **kwargs):
@@ -1860,6 +1889,10 @@ class Authentication():
         if self.user_agent:
             headers = kwargs.get('headers',{})
             headers['User-Agent'] = self.user_agent
+            kwargs['headers'] = headers
+        if self.custom_headers:
+            headers = kwargs.get('headers',{})
+            headers.update(self.custom_headers)
             kwargs['headers'] = headers
         return requests.delete(*args, timeout=30.0, **kwargs)
 
@@ -1877,6 +1910,12 @@ class Authentication():
         self.set_resource_uri(args.resource)
         self.set_scope(args.scope)
         self.set_user_agent(args.user_agent)
+        if hasattr(args, 'headers') and args.headers:
+            try:
+                headers_dict = json.loads(args.headers)
+                self.set_custom_headers(headers_dict)
+            except json.JSONDecodeError:
+                print(f'Error: Invalid JSON format for headers: {args.headers}')
         if args.cae:
             self.set_cae()
         if args.force_mfa:

--- a/roadlib/roadtools/roadlib/auth.py
+++ b/roadlib/roadtools/roadlib/auth.py
@@ -117,7 +117,6 @@ class Authentication():
         """
         self.user_agent = self.lookup_user_agent(useragent)
 
-<<<<<<< Updated upstream
     def get_redirect_for_client(self, client_id, interactive=False, broker=False):
         """
         Try to resolve a valid redirect URI for a client, using roadtx lookup if available.
@@ -128,14 +127,13 @@ class Authentication():
             return utils.find_redirurl_for_client(client_id, interactive=interactive, broker=broker)
         except Exception:
             return 'https://login.microsoftonline.com/common/oauth2/nativeclient'
-=======
+
     def set_custom_headers(self, headers_dict):
         """
         Sets custom headers to include in all HTTP requests
         """
         if headers_dict:
             self.custom_headers = headers_dict
->>>>>>> Stashed changes
 
     def user_discovery_v1(self, username):
         """

--- a/roadtx/roadtools/roadtx/main.py
+++ b/roadtx/roadtools/roadtx/main.py
@@ -84,6 +84,9 @@ def main():
                                  '--broker-redirect-url',
                                  action='store',
                                  help='Broker redirect URL (for Nested App Auth)')
+    rttsauth_parser.add_argument('--headers',
+                                 action='store',
+                                 help='Custom headers in JSON format, e.g., \'{"X-AnchorMailbox": "Oid:objectid@tenantid"}\'')
 
     # Construct device module
     device_parser = subparsers.add_parser('device', help='Register or join devices to Azure AD')
@@ -708,6 +711,9 @@ def main():
     intauth_parser.add_argument('--otpseed',
                                 action='store',
                                 help='TOTP seed to calculate MFA code when prompted')
+    intauth_parser.add_argument('--headers',
+                                action='store',
+                                help='Custom headers in JSON format, e.g., \'{"X-AnchorMailbox": "Oid:objectid@tenantid"}\'')
 
     # Interactive auth using Selenium - creds from keepass
     kdbauth_parser = subparsers.add_parser('keepassauth', help='Selenium based authentication with credentials from a KeePass database')
@@ -1091,6 +1097,13 @@ def main():
         auth.set_user_agent(args.user_agent)
         auth.set_scope(args.scope)
         auth.outfile = args.tokenfile
+        if args.headers:
+            try:
+                headers_dict = json.loads(args.headers)
+                auth.set_custom_headers(headers_dict)
+            except json.JSONDecodeError:
+                print(f'Error: Invalid JSON format for headers: {args.headers}')
+                return
         if args.origin:
             auth.set_origin_value(args.origin)
         elif 'originheader' in tokenobject:
@@ -1553,6 +1566,13 @@ def main():
         auth.set_user_agent(args.user_agent)
         auth.tenant = args.tenant
         auth.use_pkce = args.pkce
+        if args.headers:
+            try:
+                headers_dict = json.loads(args.headers)
+                auth.set_custom_headers(headers_dict)
+            except json.JSONDecodeError:
+                print(f'Error: Invalid JSON format for headers: {args.headers}')
+                return
         if args.origin:
             auth.set_origin_value(args.origin, args.redirect_url)
         if args.cae:


### PR DESCRIPTION
  **Summary**

This PR adds support for custom HTTP headers in ROADtools authentication flows. Users can now specify custom headers that will be included in all HTTP requests made during authentication and API operations.

**Changes**

roadlib (roadtools/roadlib/auth.py):
  - Added custom_headers attribute to the Authentication class to store custom headers
  - Added set_custom_headers() method to configure custom headers from a dictionary
  - Added --headers command-line argument that accepts JSON-formatted headers
  - Modified all HTTP request methods (requests_get, requests_post, requests_put, requests_patch, requests_delete) to include custom headers in their requests
  - Added JSON parsing logic in parse_args() to handle the --headers argument with error handling for invalid JSON

roadtx (roadtools/roadtx/main.py):
  - Added --headers argument to the refreshtokento subcommand
  - Added --headers argument to the interactiveauth subcommand

**Use Case**

This feature enables users to pass custom HTTP headers like X-AnchorMailbox used by for example PIM authentication flow.

**Usage Example**
roadtx gettokens --headers '{"X-AnchorMailbox": "Oid:objectid@tenantid"}'