### PR TITLE
Add --headless for interactiveauth

### DIFF
--- a/roadtx/roadtools/roadtx/main.py
+++ b/roadtx/roadtools/roadtx/main.py
@@ -715,6 +715,9 @@ def main():
     intauth_parser.add_argument('--otpseed',
                                 action='store',
                                 help='TOTP seed to calculate MFA code when prompted')
+    intauth_parser.add_argument('--headless',
+                                action='store_true',
+                                help='Run Selenium in headless mode')
 
     # Interactive auth using Selenium - creds from keepass
     kdbauth_parser = subparsers.add_parser('keepassauth', help='Selenium based authentication with credentials from a KeePass database')
@@ -1588,7 +1591,7 @@ def main():
             redirect_url = args.redirect_url
         else:
             redirect_url = find_redirurl_for_client(auth.client_id, interactive=False)
-        selauth = SeleniumAuthentication(auth, deviceauth, redirect_url, proxy=args.proxy, proxy_type=args.proxy_type)
+        selauth = SeleniumAuthentication(auth, deviceauth, redirect_url, proxy=args.proxy, proxy_type=args.proxy_type, headless=args.headless)
         if args.url:
             url = args.url
         else:

--- a/roadtx/roadtools/roadtx/selenium.py
+++ b/roadtx/roadtools/roadtx/selenium.py
@@ -41,7 +41,7 @@ def selenium_wrap(func):
     return wrapped
 
 class SeleniumAuthentication():
-    def __init__(self, auth, deviceauth, redirurl, proxy=None, proxy_type="http"):
+    def __init__(self, auth, deviceauth, redirurl, proxy=None, proxy_type="http", headless=False):
         if proxy:
             # Strip possible prefixes
             proxy = proxy.replace('http://','').replace('https://','').replace('socks://','').replace('socks4://','').replace('socks5://','')
@@ -51,7 +51,7 @@ class SeleniumAuthentication():
         self.deviceauth = deviceauth
         self.driver = None
         self.redirurl = redirurl
-        self.headless = False
+        self.headless = headless
 
     def get_service(self, driverpath):
         # Default expects geckodriver to be in path, but if it exists locally we use that


### PR DESCRIPTION
Example problematic scenario:
- Using `roadtx interactiveauth --estscookie` on a machine with no GUI (ex. Docker container)
- This creates a Selenium WebDriverException ("Process unexpectedly closed with status 255")

With the new `--headless` argument specified there is no exception and the tokens are captured as expected. The headless flag was added in #67 but no argument was added to change it.